### PR TITLE
build_rpm: fix saving built mult-spec components to repository

### DIFF
--- a/example-configs/qubes-os-r4.2-dom0.yml
+++ b/example-configs/qubes-os-r4.2-dom0.yml
@@ -15,7 +15,7 @@ verbose: true
 qubes-release: r4.2
 timeout: 3600
 
-do-merge: true
+skip-git-fetch: false
 fetch-versions-only: true
 
 distributions:

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -82,7 +82,6 @@ class Config:
     debug: Union[bool, property]                         = property(lambda self: self.get("debug", False))
     force_fetch: Union[bool, property]                   = property(lambda self: self.get("force-fetch", False))
     skip_git_fetch: Union[bool, property]                = property(lambda self: self.get("skip-git-fetch", True))
-    do_merge: Union[bool, property]                      = property(lambda self: self.get("do-merge", False))
     fetch_versions_only: Union[bool, property]           = property(lambda self: self.get("fetch-versions-only", False))
     backend_vmm: Union[str, property]                    = property(lambda self: self.get("backend-vmm", ""))
     use_qubes_repo: Union[Dict, property]                = property(lambda self: self.get("use-qubes-repo", {}))

--- a/qubesbuilder/executors/qubes.py
+++ b/qubesbuilder/executors/qubes.py
@@ -159,6 +159,7 @@ class QubesExecutor(Executor):
                     f"sed -i 's#@BUILDER_DIR@#{self.get_builder_dir()}#g' {' '.join(files)}"
                 ]
                 if sed_cmd:
+                    sed_cmd = [c.replace("'", "'\\''") for c in sed_cmd]
                     sed_cmd = [
                         "/usr/bin/qvm-run-vm",
                         dispvm,
@@ -171,6 +172,7 @@ class QubesExecutor(Executor):
                 for key, val in environment.items():
                     bash_env.append(f"{str(key)}='{str(val)}'")
 
+            cmd = [c.replace("'", "'\\''") for c in cmd]
             qvm_run_cmd = [
                 "/usr/bin/qvm-run-vm",
                 dispvm,

--- a/qubesbuilder/plugins/fetch/__init__.py
+++ b/qubesbuilder/plugins/fetch/__init__.py
@@ -125,9 +125,8 @@ class FetchPlugin(ComponentPlugin):
         if self.component.less_secure_signed_commits_sufficient:
             get_sources_cmd += ["--less-secure-signed-commits-sufficient"]
 
-        # We prioritize do merge versions first
-        if local_source_dir.exists() and self.config.do_merge:
-            get_sources_cmd += ["--do-merge"]
+        # We prioritize versions first
+        if local_source_dir.exists():
             if self.config.fetch_versions_only:
                 get_sources_cmd += ["--fetch-versions-only"]
 

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
@@ -264,7 +264,11 @@ if [[ -d "$REPO" ]]; then
     fi
     rev="$(git rev-parse -q --verify FETCH_HEAD)"
     if [ "$FETCH_VERSIONS_ONLY" == "1" ]; then
-        git tag --points-at "$rev" | grep -q '^v'
+        if ! git tag --points-at "$rev" | grep -q '^v'; then
+            echo "No version tag"
+            rm -f .git/FETCH_HEAD
+            exit 0
+        fi
     fi
     VERIFY_REF="$rev"
     fresh_clone=false

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
@@ -40,7 +40,6 @@ Options:
     --component                              Component to clone.
     --clean                                  Remove previous sources (use git up vs git clone).
     --fetch-only                             Fetch sources but do not merge.
-    --do-merge                               Merge fetched commits
     --fetch-versions-only                    Fetch only version tags
     --ignore-missing                         Exit with code 0 if remote branch doesn't exists.
     --repo                                   Specify repository directory, component will be guessed based on basename.
@@ -91,9 +90,9 @@ exit_clean() {
 
 unset GETOPT_COMPATIBLE fresh_clone GIT_CLONE_FAST GIT_BASEURL GIT_PREFIX GIT_SUFFIX GIT_URL GIT_REMOTE BRANCH \
     COMPONENT CLEAN FETCH_ONLY IGNORE_MISSING REPO KEYS_DIR KEYRING_DIR_GIT INSECURE_SKIP_CHECKING LESS_SECURE_SIGNED_COMMITS_SUFFICIENT \
-    DO_MERGE FETCH_VERSIONS_ONLY MAINTAINERS
+    FETCH_VERSIONS_ONLY MAINTAINERS
 
-if ! OPTS=$(getopt -o '' -l help,git-baseurl:,git-prefix:,git-suffix:,git-url:,git-remote:,git-branch:,component:,clean,fetch-only,ignore-missing,repo:,keys-dir:,keyring-dir-git:,insecure-skip-checking,less-secure-signed-commits-sufficient,do-merge,fetch-versions-only,maintainer: -n "$0" -- "$@"); then
+if ! OPTS=$(getopt -o '' -l help,git-baseurl:,git-prefix:,git-suffix:,git-url:,git-remote:,git-branch:,component:,clean,fetch-only,ignore-missing,repo:,keys-dir:,keyring-dir-git:,insecure-skip-checking,less-secure-signed-commits-sufficient,fetch-versions-only,maintainer: -n "$0" -- "$@"); then
     echo "ERROR: Failed while parsing options."
     exit 1
 fi
@@ -157,9 +156,6 @@ while [[ $# -gt 0 ]]; do
         ;;
     --less-secure-signed-commits-sufficient)
         LESS_SECURE_SIGNED_COMMITS_SUFFICIENT=1
-        ;;
-    --do-merge)
-        DO_MERGE=1
         ;;
     --fetch-versions-only)
         FETCH_VERSIONS_ONLY=1
@@ -250,10 +246,6 @@ elif ! [[ "$REPO" =~ ^[A-Za-z][A-Za-z0-9-]*$ ]]; then
     exit 1
 fi
 
-if [ "${FETCH_ONLY}" == "1" ] && [ "${DO_MERGE}" == "1" ]; then
-    echo "WARNING: Both fetch only and do merge are requested. Merging will be ignored."
-fi
-
 trap 'exit_clean' 0 1 2 3 6 15
 
 fresh_clone=false
@@ -267,19 +259,14 @@ if [[ -d "$REPO" ]]; then
         GIT_OPTIONS+=("--unshallow")
     fi
     print_headers
-    if [ "$DO_MERGE" == "1" ]; then
-        git fetch
-        rev="$(git rev-parse -q --verify FETCH_HEAD)"
-        if [ "$FETCH_VERSIONS_ONLY" == "1" ]; then
-            git tag --points-at "$rev" | grep -q '^v'
-        fi
-        VERIFY_REF="$rev"
-    else
-        if ! git fetch "${GIT_OPTIONS[@]}" -q --tags -- "$GIT_URL" "$BRANCH"; then
-            if [ "$IGNORE_MISSING" = "1" ]; then exit 0; else exit 1; fi
-        fi
-        VERIFY_REF=FETCH_HEAD
+    if ! git fetch "${GIT_OPTIONS[@]}" -q --tags -- "$GIT_URL" "$BRANCH"; then
+        if [ "$IGNORE_MISSING" = "1" ]; then exit 0; else exit 1; fi
     fi
+    rev="$(git rev-parse -q --verify FETCH_HEAD)"
+    if [ "$FETCH_VERSIONS_ONLY" == "1" ]; then
+        git tag --points-at "$rev" | grep -q '^v'
+    fi
+    VERIFY_REF="$rev"
     fresh_clone=false
     # shellcheck disable=SC2103
     cd - >/dev/null
@@ -423,16 +410,11 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" ] || "$fresh_clone"; then
 fi
 
 if ! "$fresh_clone"; then
-    if [ "$DO_MERGE" = "1" ]; then
-        echo "Merging FETCH_HEAD into $REPO"
-        git -c merge.verifySignatures=false merge "${GIT_MERGE_OPTS[@]}" --no-edit "$VERIFY_REF"
-    else
-        echo "--> Merging..."
-        git -c merge.verifySignatures=no merge "${GIT_MERGE_OPTS[@]}" --commit -q "$VERIFY_REF"
-        tracking_branch="refs/remotes/$GIT_REMOTE/$BRANCH"
-        if [ -f ".git/$tracking_branch" ]; then
-            git update-ref -- "$tracking_branch" "$VERIFY_REF"
-        fi
+    echo "--> Merging..."
+    git -c merge.verifySignatures=no merge "${GIT_MERGE_OPTS[@]}" --commit -q "$VERIFY_REF"
+    tracking_branch="refs/remotes/$GIT_REMOTE/$BRANCH"
+    if [ -f ".git/$tracking_branch" ]; then
+        git update-ref -- "$tracking_branch" "$VERIFY_REF"
     fi
 fi
 

--- a/qubesbuilder/plugins/sign_rpm/__init__.py
+++ b/qubesbuilder/plugins/sign_rpm/__init__.py
@@ -28,7 +28,10 @@ from qubesbuilder.pluginmanager import PluginManager
 from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import RPMDistributionPlugin
 from qubesbuilder.plugins.build import BuildError
-from qubesbuilder.plugins.build_rpm import provision_local_repository
+from qubesbuilder.plugins.build_rpm import (
+    provision_local_repository,
+    clean_local_repository,
+)
 from qubesbuilder.plugins.sign import SignPlugin, SignError
 
 log = get_logger("sign_rpm")
@@ -110,6 +113,10 @@ class RPMSignPlugin(RPMDistributionPlugin, SignPlugin):
             # Clear temporary dir
             shutil.rmtree(temp_dir)
 
+        # Prepare for re-provisioning local directory
+        repository_dir = self.get_repository_dir() / self.dist.distribution
+        clean_local_repository(repository_dir, self.component, self.dist, False)
+
         for build in parameters["build"]:
             # spec file basename will be used as prefix for some artifacts
             build_bn = build.mangle()
@@ -155,7 +162,6 @@ class RPMSignPlugin(RPMDistributionPlugin, SignPlugin):
                 raise SignError(msg) from e
 
             # Re-provision builder local repository with signatures
-            repository_dir = self.get_repository_dir() / self.dist.distribution
             try:
                 provision_local_repository(
                     build=build,

--- a/qubesbuilder/plugins/source_deb/__init__.py
+++ b/qubesbuilder/plugins/source_deb/__init__.py
@@ -236,12 +236,6 @@ class DEBSourcePlugin(DEBDistributionPlugin, SourcePlugin):
             # Init command with .qubesbuilder command entries
             cmd = parameters.get("source", {}).get("commands", [])
 
-            # Update changelog
-            cmd += [
-                f"{executor.get_plugins_dir()}/source_deb/scripts/modify-changelog-for-build "
-                f"{source_dir} {directory} {self.dist.name} {self.dist.tag}",
-            ]
-
             if package_type == "quilt":
                 if self.component.is_salt():
                     copy_in += [
@@ -271,6 +265,12 @@ class DEBSourcePlugin(DEBDistributionPlugin, SourcePlugin):
                     cmd.append(
                         f"mv {executor.get_distfiles_dir() / self.component.name / fn} {executor.get_builder_dir()}/{source_orig}"
                     )
+
+            # Update changelog, after create-archive
+            cmd += [
+                f"{executor.get_plugins_dir()}/source_deb/scripts/modify-changelog-for-build "
+                f"{source_dir} {directory} {self.dist.name} {self.dist.tag}",
+            ]
 
             gen_packages_list_cmd = [
                 f"{executor.get_plugins_dir()}/source_deb/scripts/debian-get-packages-list",

--- a/qubesbuilder/plugins/upload/__init__.py
+++ b/qubesbuilder/plugins/upload/__init__.py
@@ -93,10 +93,10 @@ class UploadPlugin(DistributionPlugin):
                         self.dist, repository_publish
                     )
                 )
+                directories_to_upload.append(f"{self.dist.package_set}/pool")
                 directories_to_upload.append(
                     f"{self.dist.package_set}/dists/{debian_suite}"
                 )
-                directories_to_upload.append(f"{self.dist.package_set}/pool")
 
             if not directories_to_upload:
                 raise UploadError(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,6 +262,11 @@ def test_component_build_host_fc32(artifacts_dir):
     }
     srpm = "qubes-core-qrexec-4.1.18-1.fc32.src.rpm"
 
+    for rpm in rpms.union({srpm}):
+        assert (
+            artifacts_dir / "repository/host-fc32/core-qrexec_4.1.18" / rpm
+        ).exists()
+
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
     assert info.get("srpm", None) == srpm
@@ -278,6 +283,11 @@ def test_component_build_host_fc32(artifacts_dir):
         "qubes-core-qrexec-dom0-debugsource-4.1.18-1.fc32.x86_64.rpm",
     }
     srpm = "qubes-core-qrexec-dom0-4.1.18-1.fc32.src.rpm"
+
+    for rpm in rpms.union({srpm}):
+        assert (
+            artifacts_dir / "repository/host-fc32/core-qrexec_4.1.18" / rpm
+        ).exists()
 
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))


### PR DESCRIPTION
Do not remove target dir for every spec, as that breaks multi-spec
components. All directories for a given component are already removed at
the beginning of the build.