### PR TITLE
fetch: make fresh clone respect FETCH_VERSIONS_ONLY too

### DIFF
--- a/qubesbuilder/common.py
+++ b/qubesbuilder/common.py
@@ -19,6 +19,7 @@
 import re
 import shutil
 import tempfile
+from enum import Enum
 from pathlib import Path
 from string import digits, ascii_letters
 
@@ -44,6 +45,13 @@ STAGES_ALIAS = {
     "u": "upload",
 }
 FORBIDDEN_PATTERNS = [".."]
+
+
+class VerificationMode(Enum):
+    SignedTag = "signed-tag"
+    SignedCommit = "less-secure-signed-commits-sufficient"
+    Insecure = "insecure-skip-checking"
+
 
 for s in STAGES:
     FORBIDDEN_PATTERNS += [f".{s}.yml", f".{s}.yaml"]

--- a/qubesbuilder/component.py
+++ b/qubesbuilder/component.py
@@ -42,6 +42,7 @@ class QubesComponent:
         verification_mode: VerificationMode = VerificationMode.SignedCommit,
         maintainers: List = None,
         timeout: int = None,
+        fetch_versions_only: bool = False,
     ):
         self.source_dir: Path = (
             Path(source_dir) if isinstance(source_dir, str) else source_dir
@@ -54,6 +55,7 @@ class QubesComponent:
         self.maintainers = maintainers or []
         self.verification_mode = verification_mode
         self.timeout = timeout
+        self.fetch_versions_only = fetch_versions_only
         self._source_hash = ""
 
     def get_parameters(self, placeholders: dict = None):

--- a/qubesbuilder/component.py
+++ b/qubesbuilder/component.py
@@ -28,7 +28,7 @@ import pathspec
 import yaml
 from packaging.version import Version, InvalidVersion
 
-from qubesbuilder.common import sanitize_line, deep_check
+from qubesbuilder.common import sanitize_line, deep_check, VerificationMode
 from qubesbuilder.exc import ComponentError, NoQubesBuilderFileError
 
 
@@ -39,8 +39,7 @@ class QubesComponent:
         name: str = None,
         url: str = None,
         branch: str = "master",
-        insecure_skip_checking: bool = False,
-        less_secure_signed_commits_sufficient: bool = False,
+        verification_mode: VerificationMode = VerificationMode.SignedCommit,
         maintainers: List = None,
         timeout: int = None,
     ):
@@ -53,10 +52,7 @@ class QubesComponent:
         self.url = url or f"https://github.com/QubesOS/qubes-{self.name}"
         self.branch = branch
         self.maintainers = maintainers or []
-        self.insecure_skip_checking = insecure_skip_checking
-        self.less_secure_signed_commits_sufficient = (
-            less_secure_signed_commits_sufficient
-        )
+        self.verification_mode = verification_mode
         self.timeout = timeout
         self._source_hash = ""
 

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -320,6 +320,9 @@ class Config:
             verification_mode = VerificationMode.SignedCommit
         if "verification-mode" in options:
             verification_mode = VerificationMode(options["verification-mode"])
+        fetch_versions_only = options.get(
+            "fetch-versions-only", self.get("fetch-versions-only", False)
+        )
         component = QubesComponent(
             source_dir=self._artifacts_dir / "sources" / name,
             url=options.get("url", url),
@@ -327,6 +330,7 @@ class Config:
             maintainers=options.get("maintainers", maintainers),
             verification_mode=verification_mode,
             timeout=options.get("timeout", timeout),
+            fetch_versions_only=fetch_versions_only,
         )
         return component
 

--- a/qubesbuilder/plugins/fetch/__init__.py
+++ b/qubesbuilder/plugins/fetch/__init__.py
@@ -126,7 +126,7 @@ class FetchPlugin(ComponentPlugin):
         elif self.component.verification_mode == VerificationMode.SignedCommit:
             get_sources_cmd += ["--less-secure-signed-commits-sufficient"]
 
-        if self.config.fetch_versions_only:
+        if self.component.fetch_versions_only:
             get_sources_cmd += ["--fetch-versions-only"]
 
         do_fetch = True

--- a/qubesbuilder/plugins/fetch/__init__.py
+++ b/qubesbuilder/plugins/fetch/__init__.py
@@ -125,10 +125,8 @@ class FetchPlugin(ComponentPlugin):
         if self.component.less_secure_signed_commits_sufficient:
             get_sources_cmd += ["--less-secure-signed-commits-sufficient"]
 
-        # We prioritize versions first
-        if local_source_dir.exists():
-            if self.config.fetch_versions_only:
-                get_sources_cmd += ["--fetch-versions-only"]
+        if self.config.fetch_versions_only:
+            get_sources_cmd += ["--fetch-versions-only"]
 
         do_fetch = True
         if local_source_dir.exists():

--- a/qubesbuilder/plugins/fetch/__init__.py
+++ b/qubesbuilder/plugins/fetch/__init__.py
@@ -25,6 +25,7 @@ import urllib.parse
 from pathlib import Path
 from typing import Any
 
+from qubesbuilder.common import VerificationMode
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.config import Config
 from qubesbuilder.exc import NoQubesBuilderFileError
@@ -120,9 +121,9 @@ class FetchPlugin(ComponentPlugin):
         ]
         for maintainer in self.component.maintainers:
             get_sources_cmd += ["--maintainer", maintainer]
-        if self.component.insecure_skip_checking:
+        if self.component.verification_mode == VerificationMode.Insecure:
             get_sources_cmd += ["--insecure-skip-checking"]
-        if self.component.less_secure_signed_commits_sufficient:
+        elif self.component.verification_mode == VerificationMode.SignedCommit:
             get_sources_cmd += ["--less-secure-signed-commits-sufficient"]
 
         if self.config.fetch_versions_only:

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
@@ -280,7 +280,19 @@ else
     if ! git clone "${GIT_OPTIONS[@]}" -n -q -b "$BRANCH" "$GIT_URL" "$REPO"; then
         if [ "$IGNORE_MISSING" == "1" ]; then exit 0; else exit 1; fi
     fi
-    VERIFY_REF=HEAD fresh_clone=:
+    if [ "$FETCH_VERSIONS_ONLY" == "1" ]; then
+        vtag=$(git -C "$REPO" describe --match='v*' --abbrev=0 HEAD)
+        if [ -n "$vtag" ]; then
+            VERIFY_REF="$vtag^{commit}"
+        else
+            echo "No version tag"
+            # no version tag at all, abort
+            exit 1
+        fi
+    else
+        VERIFY_REF=HEAD
+    fi
+    fresh_clone=:
 fi
 
 export CHECK=signed-tag
@@ -400,7 +412,9 @@ if [ "$CURRENT_BRANCH" != "$BRANCH" ] || "$fresh_clone"; then
     fi
     if [ -n "$(git name-rev --name-only "$BRANCH" 2>/dev/null)" ]; then
         echo "--> Switching branch from $CURRENT_BRANCH branch to ${green}$BRANCH${normal}"
-        git merge-base --is-ancestor -- "$BRANCH" "$VERIFY_REF" || exit 1
+        if ! "$fresh_clone"; then
+            git merge-base --is-ancestor -- "$BRANCH" "$VERIFY_REF" || exit 1
+        fi
         git checkout -B "$BRANCH" "$VERIFY_REF" || exit 1
     else
         echo -e "--> Switching branch from $CURRENT_BRANCH branch to new ${red}$BRANCH${normal}"

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -237,3 +237,48 @@ components:
         config = Config(config_file.name)
         component = config.get_components(['example'])[0]
         assert component.verification_mode == VerificationMode.SignedTag
+
+
+def test_config_fetch_versions_only():
+    with tempfile.NamedTemporaryFile('w') as config_file:
+        config_file.write("""components:
+ - example:
+     fetch-versions-only: True
+""")
+        config_file.flush()
+        config = Config(config_file.name)
+        component = config.get_components(['example'])[0]
+        assert component.fetch_versions_only == True
+
+    with tempfile.NamedTemporaryFile('w') as config_file:
+        config_file.write("""
+fetch-versions-only: True
+components:
+ - example:
+     fetch-versions-only: False
+""")
+        config_file.flush()
+        config = Config(config_file.name)
+        component = config.get_components(['example'])[0]
+        assert component.fetch_versions_only == False
+
+    with tempfile.NamedTemporaryFile('w') as config_file:
+        config_file.write("""
+fetch-versions-only: True
+components:
+ - example
+""")
+        config_file.flush()
+        config = Config(config_file.name)
+        component = config.get_components(['example'])[0]
+        assert component.fetch_versions_only == True
+
+    with tempfile.NamedTemporaryFile('w') as config_file:
+        config_file.write("""
+components:
+ - example
+""")
+        config_file.flush()
+        config = Config(config_file.name)
+        component = config.get_components(['example'])[0]
+        assert component.fetch_versions_only == False


### PR DESCRIPTION
Go back to the latest version tag when doing fresh clone.
This requires also disabling anti-rollback protection for fresh clone
(rollback is actually intentional in this case).