### PR TITLE
Improve getting component(s) from the config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ generate-container-image:
   variables:
     PYTHONPATH: .
     TMPDIR: /home/user
-    PYTEST_ARGS: -v --color=yes --cov qubesbuilder --cov-report term --cov-report html:artifacts/htmlcov --cov-report xml:artifacts/coverage.xml --junitxml=artifacts/qubesbuilder.xml
+    PYTEST_ARGS: -v --color=yes --showlocals --cov qubesbuilder --cov-report term --cov-report html:artifacts/htmlcov --cov-report xml:artifacts/coverage.xml --junitxml=artifacts/qubesbuilder.xml
 
 pytest:
   extends: .pytest

--- a/qubesbuilder/cli/cli_base.py
+++ b/qubesbuilder/cli/cli_base.py
@@ -23,12 +23,16 @@ QubesBuilder command-line interface - base module.
 
 import sys
 import traceback
-from typing import Callable
+from pathlib import Path
+from typing import Callable, List, Optional
 
 import click
 
+from qubesbuilder.component import QubesComponent
 from qubesbuilder.config import Config
+from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.pluginmanager import PluginManager
+from qubesbuilder.template import QubesTemplate
 
 
 class ContextObj:
@@ -39,10 +43,10 @@ class ContextObj:
     def __init__(self, config: Config):
         self.config = config
         self.manager = PluginManager(config.get_plugins_dirs())
-        self.components = None
-        self.distributions = None
-        self.templates = None
-        self.log_file = None
+        self.components: List[QubesComponent] = []
+        self.distributions: List[QubesDistribution] = []
+        self.templates: List[QubesTemplate] = []
+        self.log_file: Optional[Path] = None
 
 
 class AliasedGroup(click.Group):

--- a/qubesbuilder/cli/cli_main.py
+++ b/qubesbuilder/cli/cli_main.py
@@ -23,7 +23,7 @@ QubesBuilder command-line interface.
 
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import click
 
@@ -47,9 +47,9 @@ def init_context_obj(
     verbose: int = None,
     debug: bool = None,
     log_file: str = None,
-    component: List = None,
-    distribution: List = None,
-    template: List = None,
+    component: Optional[List] = None,
+    distribution: Optional[List] = None,
+    template: Optional[List] = None,
     executor: str = None,
     executor_option: List = None,
 ):

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -231,23 +231,23 @@ class Config:
             components_from_config = []
             for c in self._conf.get("components", []):
                 components_from_config.append(self.get_component_from_dict_or_string(c))
+            self._components = components_from_config
 
-            # Find if components requested would have been found from config file with
-            # non default values for url, maintainer, etc.
-            if filtered_components:
-                for fc in filtered_components:
-                    filtered_component = None
-                    for c in components_from_config:
-                        if c.name == fc:
-                            filtered_component = c
-                            break
-                    if not filtered_component:
-                        filtered_component = self.get_component_from_dict_or_string(fc)
-                    self._components.append(filtered_component)
-            else:
-                self._components = components_from_config
-
-        return self._components
+        # Find if components requested would have been found from config file with
+        # non default values for url, maintainer, etc.
+        if filtered_components:
+            result = []
+            for fc in filtered_components:
+                found = False
+                for c in self._components:
+                    if c.name == fc:
+                        result.append(c)
+                        found = True
+                if not found:
+                    raise ConfigError(f"No such component: {fc}")
+            return result
+        else:
+            return self._components
 
     def get_artifacts_dir(self):
         return self._artifacts_dir

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -220,16 +220,18 @@ class Config:
 
     def get_templates(self, filtered_templates=None):
         if not self._templates:
-            if filtered_templates:
-                templates = []
-                for template_name in filtered_templates:
-                    for tmpl in self._conf.get("templates", []):
-                        if next(iter(tmpl.keys())) == template_name:
-                            templates.append(tmpl)
-                            break
-            else:
-                templates = self._conf.get("templates", [])
+            templates = self._conf.get("templates", [])
             self._templates = [QubesTemplate(template) for template in templates]
+        if filtered_templates:
+            result = []
+            for ft in filtered_templates:
+                for t in self._templates:
+                    if t.name == ft:
+                        result.append(t)
+                        break
+                else:
+                    raise ConfigError(f"No such template: {ft}")
+            return result
         return self._templates
 
     def get_components(self, filtered_components=None, url_match=False):

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -204,11 +204,18 @@ class Config:
 
     def get_distributions(self, filtered_distributions=None):
         if not self._dists:
-            if filtered_distributions:
-                distributions = filtered_distributions
-            else:
-                distributions = self._conf.get("distributions", [])
+            distributions = self._conf.get("distributions", [])
             self._dists = [QubesDistribution(dist) for dist in distributions]
+        if filtered_distributions:
+            result = []
+            for fd in filtered_distributions:
+                for d in self._dists:
+                    if d.distribution == fd:
+                        result.append(d)
+                        break
+                else:
+                    raise ConfigError(f"No such distribution: {fd}")
+            return result
         return self._dists
 
     def get_templates(self, filtered_templates=None):

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -225,7 +225,7 @@ class Config:
             self._templates = [QubesTemplate(template) for template in templates]
         return self._templates
 
-    def get_components(self, filtered_components=None):
+    def get_components(self, filtered_components=None, url_match=False):
         if not self._components:
             # Load available component information from config
             components_from_config = []
@@ -237,10 +237,14 @@ class Config:
         # non default values for url, maintainer, etc.
         if filtered_components:
             result = []
+            prefix = self.get("git", {}).get("prefix", "QubesOS/qubes-")
             for fc in filtered_components:
                 found = False
                 for c in self._components:
                     if c.name == fc:
+                        result.append(c)
+                        found = True
+                    elif url_match and c.url.partition(prefix)[2] == fc:
                         result.append(c)
                         found = True
                 if not found:

--- a/qubesbuilder/plugins/__init__.py
+++ b/qubesbuilder/plugins/__init__.py
@@ -311,7 +311,9 @@ class DistributionComponentPlugin(DistributionPlugin, ComponentPlugin):
         # For retro-compatibility
         if self.dist.type == "rpm":
             self._parameters["build"] += [
-                PackagePath(spec) for spec in self._parameters.get("spec", [])
+                PackagePath(spec)
+                for spec in self._parameters.get("spec", [])
+                if PackagePath(spec) not in self._parameters["build"]
             ]
         # Check conflicts when mangle paths
         mangle_builds = [build.mangle() for build in self._parameters.get("build", [])]

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
@@ -262,7 +262,7 @@ if [[ -d "$REPO" ]]; then
     if ! git fetch "${GIT_OPTIONS[@]}" -q --tags -- "$GIT_URL" "$BRANCH"; then
         if [ "$IGNORE_MISSING" = "1" ]; then exit 0; else exit 1; fi
     fi
-    rev="$(git rev-parse -q --verify FETCH_HEAD)"
+    rev="$(git rev-parse -q --verify "FETCH_HEAD^{commit}")"
     if [ "$FETCH_VERSIONS_ONLY" == "1" ]; then
         if ! git tag --points-at "$rev" | grep -q '^v'; then
             echo "No version tag"

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -28,6 +28,7 @@ distributions:
   - host-fc32
   - vm-bullseye
   - vm-fc36
+  - vm-centos-stream8
 
 components:
   - python-qasync:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,24 +87,25 @@ def rpm_packages_list(repository_dir):
 # config
 #
 
+
 def test_config(artifacts_dir):
     with tempfile.TemporaryDirectory() as tmpdir:
-        include_path = os.path.join(tmpdir, 'include1.yml')
-        with open(include_path, 'w') as f:
+        include_path = os.path.join(tmpdir, "include1.yml")
+        with open(include_path, "w") as f:
             f.write("+components:\n")
             f.write("- component2\n")
             f.write("- component3\n")
             f.write("distributions:\n")
             f.write("- vm-fc36\n")
             f.write("- vm-fc37\n")
-        include_path = os.path.join(tmpdir, 'include-nested.yml')
-        with open(include_path, 'w') as f:
+        include_path = os.path.join(tmpdir, "include-nested.yml")
+        with open(include_path, "w") as f:
             f.write("+components:\n")
             f.write("- component4\n")
             f.write("- component5\n")
             f.write("debug: true\n")
-        include_path = os.path.join(tmpdir, 'include2.yml')
-        with open(include_path, 'w') as f:
+        include_path = os.path.join(tmpdir, "include2.yml")
+        with open(include_path, "w") as f:
             f.write("include:\n")
             f.write("- include-nested.yml\n")
             f.write("+components:\n")
@@ -113,8 +114,8 @@ def test_config(artifacts_dir):
             f.write("distributions:\n")
             f.write("- vm-fc36\n")
             f.write("- vm-fc37\n")
-        config_path = os.path.join(tmpdir, 'builder.yml')
-        with open(config_path, 'w') as f:
+        config_path = os.path.join(tmpdir, "builder.yml")
+        with open(config_path, "w") as f:
             f.write("include:\n")
             f.write("- include1.yml\n")
             f.write("- include2.yml\n")
@@ -125,18 +126,22 @@ def test_config(artifacts_dir):
             f.write("- vm-fc33\n")
             f.write("- vm-fc34\n")
 
-        output = qb_call_output(config_path, artifacts_dir,
-                                "config", "get-components")
-        assert output == b"component1\ncomponent2\ncomponent3\ncomponent4\n" \
-                         b"component5\ncomponent6\ncomponent7\n"
+        output = qb_call_output(config_path, artifacts_dir, "config", "get-components")
+        assert (
+            output == b"component1\ncomponent2\ncomponent3\ncomponent4\n"
+            b"component5\ncomponent6\ncomponent7\n"
+        )
 
-        output = qb_call_output(config_path, artifacts_dir,
-                                "config", "get-distributions")
+        output = qb_call_output(
+            config_path, artifacts_dir, "config", "get-distributions"
+        )
         assert output == b"vm-fc33\nvm-fc34\n"
 
-        output = qb_call_output(config_path, artifacts_dir,
-                                "config", "get-var", "debug")
+        output = qb_call_output(
+            config_path, artifacts_dir, "config", "get-var", "debug"
+        )
         assert output == b"true\n"
+
 
 #
 # Fetch

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -196,91 +196,107 @@ def test_template():
 
 
 def test_config_verification():
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""components:
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """components:
  - example:
      verification-mode: less-secure-signed-commits-sufficient
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.verification_mode == VerificationMode.SignedCommit
 
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""components:
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """components:
  - example:
      verification-mode: insecure-skip-checking
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.verification_mode == VerificationMode.Insecure
 
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """
 less-secure-signed-commits-sufficient:
  - example
 components:
  - example
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.verification_mode == VerificationMode.SignedCommit
 
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """
 components:
  - example
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.verification_mode == VerificationMode.SignedTag
 
 
 def test_config_fetch_versions_only():
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""components:
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """components:
  - example:
      fetch-versions-only: True
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.fetch_versions_only == True
 
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """
 fetch-versions-only: True
 components:
  - example:
      fetch-versions-only: False
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.fetch_versions_only == False
 
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """
 fetch-versions-only: True
 components:
  - example
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.fetch_versions_only == True
 
-    with tempfile.NamedTemporaryFile('w') as config_file:
-        config_file.write("""
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """
 components:
  - example
-""")
+"""
+        )
         config_file.flush()
         config = Config(config_file.name)
-        component = config.get_components(['example'])[0]
+        component = config.get_components(["example"])[0]
         assert component.fetch_versions_only == False
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -313,3 +313,34 @@ def test_config_components_filter():
         assert [c.name for c in config.get_components(["component3"])] == ["component3"]
         with pytest.raises(ConfigError):
             config.get_components(["no-such-component"])
+
+
+def test_config_distributions_filter():
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """distributions:
+ - vm-fc36
+ - vm-bullseye
+ - host-fc37
+"""
+        )
+        config_file.flush()
+        config = Config(config_file.name)
+
+        assert [d.distribution for d in config.get_distributions()] == [
+            "vm-fc36",
+            "vm-bullseye",
+            "host-fc37",
+        ]
+        assert [d.distribution for d in config.get_distributions(["vm-fc36"])] == [
+            "vm-fc36"
+        ]
+        assert [
+            d.distribution
+            for d in config.get_distributions(["vm-fc36", "host-fc37"])
+        ] == [
+            "vm-fc36",
+            "host-fc37",
+        ]
+        with pytest.raises(ConfigError):
+            config.get_distributions(["vm-fc32"])

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -360,3 +360,41 @@ def test_config_distributions_filter():
         ]
         with pytest.raises(ConfigError):
             config.get_distributions(["vm-fc32"])
+
+
+def test_config_templates_filter():
+    with tempfile.NamedTemporaryFile("w") as config_file:
+        config_file.write(
+            """templates:
+  - fedora-36-xfce:
+      dist: fc36
+      flavor: xfce
+  - centos-stream-8:
+      dist: centos-stream8
+  - debian-11:
+      dist: bullseye
+      options:
+        - standard
+        - firmware
+"""
+        )
+        config_file.flush()
+        config = Config(config_file.name)
+
+        assert [t.name for t in config.get_templates()] == [
+            "fedora-36-xfce",
+            "centos-stream-8",
+            "debian-11",
+        ]
+        assert [t.name for t in config.get_templates(["debian-11"])] == ["debian-11"]
+        assert [
+            t.name
+            for t in config.get_templates(
+                ["fedora-36-xfce", "debian-11"]
+            )
+        ] == [
+            "fedora-36-xfce",
+            "debian-11",
+        ]
+        with pytest.raises(ConfigError):
+            config.get_templates(["fedora-32"])

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -306,6 +306,10 @@ def test_config_components_filter():
         ]
         assert [c.name for c in config.get_components(["component2"])] == ["component2"]
         assert [c.name for c in config.get_components(["component1"])] == ["component1"]
+        assert [c.name for c in config.get_components(["component1"], True)] == [
+            "component1",
+            "component3",
+        ]
         assert [c.name for c in config.get_components(["component3"])] == ["component3"]
         with pytest.raises(ConfigError):
             config.get_components(["no-such-component"])


### PR DESCRIPTION
This is preparation for multiple components matching a single repository name.

This also avoids implicit declaration of components with -c option - something
that may result in confusing behavior.