### PR TITLE
Add more --define when querying spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,8 @@ Options available in `builder.yml`:
   - `branch: str` --- git branch (default: master).
   - `maintainers: List[str]` --- List of extra fingerprint allowed for signature verification of git commit and tag.
 
+- `skip-git-fetch: bool` --- When set, do not update already downloaded git repositories (those in `sources` artifacts dir). New components are still fetched (once). Useful when doing development builds from non-default branches, local modifications etc.
+
 - `artifacts-dir: str` --- Path to artifacts directory.
 
 - `plugins-dirs: List[str]` --- List of path to plugin directory. By default, the local plugins directory is prepended to the list.

--- a/qubesbuilder/plugins/source_rpm/scripts/query-builtrpms
+++ b/qubesbuilder/plugins/source_rpm/scripts/query-builtrpms
@@ -34,10 +34,13 @@ fi
 SPEC_FILE="$1"
 DIST_TAG="$2"
 
-RPM_OPS=(--define "dist .${DIST_TAG}" --nodebuginfo)
-if [ "${DIST_TAG}" == "el8" ]; then
-    RPM_OPS+=(--define "python3_pkgversion 38")
+rpm_defines=(--define "dist .${DIST_TAG}")
+
+if [ "$(type -t set_rpm_defines)" = "function" ]; then
+    set_rpm_defines "$DIST_TAG"
 fi
+
+RPM_OPS=("${rpm_defines[@]}" --nodebuginfo)
 
 # Get builtrpms from rpmspec without debuginfo
 # see https://github.com/rpm-software-management/rpm/issues/1878

--- a/qubesbuilder/plugins/source_rpm/scripts/query-spec
+++ b/qubesbuilder/plugins/source_rpm/scripts/query-spec
@@ -39,6 +39,28 @@ if [ $# -lt 4 ]; then
     exit 1
 fi
 
+rpm_defines=()
+
+# make it a function and export, as bash doesn't support exporting an array
+set_rpm_defines() {
+    local dist="$1"
+    # strip possible devel number
+    raw_dist="${dist#*.}"
+    if [[ "$raw_dist" = "fc"* ]]; then
+        dist_ver="${raw_dist#fc}"
+        rpm_defines+=(--define "fedora $dist_ver")
+    elif [[ "$raw_dist" = "el"* ]]; then
+        dist_ver="${raw_dist#el}"
+        rpm_defines+=(--define "centos $dist_ver")
+        rpm_defines+=(--define "rhel $dist_ver")
+    fi
+    if [[ "$raw_dist" = el8 ]]; then
+        rpm_defines+=(--define "python3_pkgversion 38")
+    fi
+}
+
+export -f set_rpm_defines
+
 spec_file_bn="$(basename "${spec_file}")"
 
 [[ "${spec_file_bn}.in" == ".in" ]] && exit 0


### PR DESCRIPTION
Specifically, it adds "fedora", "centos", "rhel" where appropriate. This
fixes parsing specs with conditional packages based on those variables
(like xen package).