### PR TITLE
Force refreshing source hash after fetch

### DIFF
--- a/qubesbuilder/component.py
+++ b/qubesbuilder/component.py
@@ -199,8 +199,8 @@ class QubesComponent:
                 hash = self._update_hash_from_dir(path, hash)
         return hash
 
-    def get_source_hash(self):
-        if not self._source_hash:
+    def get_source_hash(self, force_update=True):
+        if not self._source_hash or force_update:
             source_dir_hash = self._update_hash_from_dir(
                 self.source_dir, hashlib.sha512()
             ).hexdigest()

--- a/qubesbuilder/plugins/fetch/__init__.py
+++ b/qubesbuilder/plugins/fetch/__init__.py
@@ -300,7 +300,7 @@ class FetchPlugin(ComponentPlugin):
         source_dir = executor.get_builder_dir() / self.component.name
 
         # Keep existing fetch info if it is up-to-date
-        source_hash = self.component.get_source_hash()
+        source_hash = self.component.get_source_hash(force_update=True)
         old_info = self.get_artifacts_info(stage=stage, basename="source")
         if "source-hash" in old_info and old_info["source-hash"] == source_hash:
             return


### PR DESCRIPTION
Component object may have a source hash cached from before fetching new
sources. This results in new source info saved with old hash, which then
breaks detection if rebuild can be skipped. Force the update after fetch.