### PR TITLE
Fix handling -rc versions

### DIFF
--- a/qubesbuilder/component.py
+++ b/qubesbuilder/component.py
@@ -32,6 +32,16 @@ from qubesbuilder.common import sanitize_line, deep_check, VerificationMode
 from qubesbuilder.exc import ComponentError, NoQubesBuilderFileError
 
 
+class QubesVersion(Version):
+    """Version class that preserves '-' in X.Y-rcZ version"""
+
+    def __init__(self, version: str) -> None:
+        super().__init__(version)
+        if "-rc" in version:
+            # pylint: disable=protected-access
+            self._version = self._version._replace(pre=("-rc", self._version.pre[1]))  # type: ignore
+
+
 class QubesComponent:
     def __init__(
         self,
@@ -96,7 +106,7 @@ class QubesComponent:
         if version_file.exists():
             try:
                 with open(version_file) as fd:
-                    version = Version(fd.read().split("\n")[0]).base_version
+                    version = str(QubesVersion(fd.read().split("\n")[0]))
             except InvalidVersion as e:
                 raise ComponentError(f"Invalid version for {self.source_dir}.") from e
         else:

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -35,6 +35,25 @@ def test_component():
         assert str(component) == os.path.basename(source_dir)
         assert repr(component) == repr_str
 
+def test_component_rc():
+    with tempfile.TemporaryDirectory() as source_dir:
+        with open(f"{source_dir}/version", "w") as f:
+            f.write("1.2.3-rc5")
+        with open(f"{source_dir}/rel", "w") as f:
+            f.write("4")
+        with open(f"{source_dir}/.qubesbuilder", "w") as f:
+            f.write("")
+        component = QubesComponent(source_dir)
+        component.get_parameters()
+
+        assert component.version == "1.2.3-rc5"
+        assert component.release == "4"
+
+        repr_str = f"<QubesComponent {os.path.basename(source_dir)}>"
+        assert component.to_str() == os.path.basename(source_dir)
+        assert str(component) == os.path.basename(source_dir)
+        assert repr(component) == repr_str
+
 
 def test_component_no_qubesbuilder():
     with tempfile.TemporaryDirectory() as source_dir:


### PR DESCRIPTION
Do not strip -rc part of the version - it is necessary to download
correct tarball (`@VERSION@` placeholder in the URL). `-` in a version
will be invalid in some package formats (in rpm it is reserved as a
"release number" separator), so the packaging scripts need to handle it
properly in components where -rc versions are expected.

Furthermore, do not strip '-' from -rc suffix (as standard Version class
do). Do this by adding wrapper class (`QubesVersion`) that restores the
dash.