### PR TITLE
ci: upload artifacts on failure too

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,6 +125,7 @@ pytest-cli-template:
   artifacts:
     paths:
       - artifacts
+    when: always
   before_script:
     - cp -r tests/gnupg ~/.gnupg
     - chmod 700 ~/.gnupg
@@ -146,6 +147,7 @@ pytest-cli-template:
   artifacts:
     paths:
       - artifacts
+    when: always
   before_script:
     - cp -r tests/gnupg ~/.gnupg
     - chmod 700 ~/.gnupg
@@ -173,6 +175,7 @@ pytest-cli-template:
   artifacts:
     paths:
       - artifacts
+    when: always
   before_script:
     - cp -r tests/gnupg ~/.gnupg
     - chmod 700 ~/.gnupg
@@ -193,6 +196,7 @@ pytest-cli-template:
   artifacts:
     paths:
       - artifacts
+    when: always
   before_script:
     - cp -r tests/gnupg ~/.gnupg
     - chmod 700 ~/.gnupg

--- a/qubesbuilder/plugins/source_deb/__init__.py
+++ b/qubesbuilder/plugins/source_deb/__init__.py
@@ -299,6 +299,11 @@ class DEBSourcePlugin(DEBDistributionPlugin, SourcePlugin):
                     f"cp -a {source_dir}/* .",
                 ]
             cmd += [
+                # Workaround for https://bugs.debian.org/796257, or rather its
+                # complementary part (asymmetry between extract and build)
+                # Taken from Dpkg::Source::Functions::fixperms, assuming umask 022
+                "chmod -R -- u+rwX,g+rX-w,o+rX-w .",
+                "chmod +x debian/rules",
                 "dpkg-source -b .",
                 " ".join(gen_packages_list_cmd),
             ]


### PR DESCRIPTION
This will ease debugging some failures, that happen only in CI.