### PR TITLE
Update orig source hashes in .changes file

### DIFF
--- a/qubesbuilder/plugins/build_deb/__init__.py
+++ b/qubesbuilder/plugins/build_deb/__init__.py
@@ -209,12 +209,11 @@ class DEBBuildPlugin(DEBDistributionPlugin, BuildPlugin):
             )
             copy_out = [
                 (
-                    results_dir / source_info["dsc"].replace(".dsc", "_amd64.changes"),
+                    results_dir / source_info["changes"],
                     artifacts_dir,
                 ),
                 (
-                    results_dir
-                    / source_info["dsc"].replace(".dsc", "_amd64.buildinfo"),
+                    results_dir / source_info["buildinfo"],
                     artifacts_dir,
                 ),
             ]
@@ -277,6 +276,16 @@ class DEBBuildPlugin(DEBDistributionPlugin, BuildPlugin):
                 f"--configfile {executor.get_builder_dir()}/pbuilder/pbuilderrc "
                 f"--othermirror \"{extra_sources}\" "
                 f"{str(executor.get_build_dir() / source_info['dsc'])}"
+            ]
+
+            # Patch .changes path to have source package checksums of the original source,
+            # not the one rebuilt during binary build. They should be reproducible
+            # in theory, but due to dpkg-source bugs sometimes they are not.
+            cmd += [
+                f"{executor.get_plugins_dir()}/build_deb/scripts/patch-changes "
+                f"{str(executor.get_build_dir() / source_info['dsc'])} "
+                f"{str(results_dir / source_info['buildinfo'])} "
+                f"{str(results_dir / source_info['changes'])}"
             ]
             # fmt: on
             try:

--- a/qubesbuilder/plugins/build_deb/scripts/patch-changes
+++ b/qubesbuilder/plugins/build_deb/scripts/patch-changes
@@ -1,0 +1,146 @@
+#!/usr/bin/python3
+#
+# The Qubes OS Project, https://www.qubes-os.org/
+#
+# Copyright (C) 2023 Marek Marczykowski-Górecki
+#                           <marmarek@invisiblethingslab.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+import argparse
+import hashlib
+import sys
+from typing import List, Dict, Type
+
+from debian.deb822 import Deb822, Changes, Dsc
+
+try:
+    from debian.deb822 import BuildInfo
+except ImportError:
+    # older 'debian' package doesn't have BuildInfo class,
+    # but it's easy enough to add
+    # pylint: disable=protected-access
+    from debian.deb822 import _gpg_multivalued
+
+    class BuildInfo(_gpg_multivalued):
+        _multivalued_fields: Dict[str, List[str]] = {
+            "checksums-md5": ["md5", "size", "name"],
+            "checksums-sha1": ["sha1", "size", "name"],
+            "checksums-sha256": ["sha256", "size", "name"],
+            "checksums-sha512": ["sha512", "size", "name"],
+        }
+
+
+from pathlib import Path
+
+
+def get_checksums(file_path: Path):
+    """
+    Get checksums needed for .changes file
+    """
+    checksums = {
+        "size": str(file_path.stat().st_size),
+    }
+    for digest in ("md5sum", "sha1", "sha256", "sha512"):
+        with file_path.open("rb") as file_obj:
+            # TODO: consider hashlib.file_digest in py3.11
+            if digest == "md5sum":
+                # python-debian uses 'md5sum' for 'md5' digest in hashlib
+                hash_obj = hashlib.new("md5")
+            else:
+                hash_obj = hashlib.new(digest)
+            buf = file_obj.read(65536)
+            while buf:
+                hash_obj.update(buf)
+                buf = file_obj.read(65536)
+            checksums[digest] = hash_obj.hexdigest()
+            if digest == "md5sum":
+                # duplicate hash as 'md5' too, for BuildInfo naming
+                checksums["md5"] = hash_obj.hexdigest()
+    return checksums
+
+
+def parse_dsc(dsc_path: Path):
+    """
+    Get checksums needed for .changes file
+    """
+
+    files_hashes = {}
+    with dsc_path.open("r") as dsc_f:
+        dsc = Dsc(dsc_f)
+        for digest, section in (
+            ("md5sum", "Files"),
+            ("sha1", "Checksums-Sha1"),
+            ("sha256", "Checksums-Sha256"),
+            ("sha512", "Checksums-Sha512"),
+        ):
+            if section not in dsc:
+                continue
+            for f_line in dsc[section]:
+                files_hashes.setdefault(f_line["name"], {})[digest] = f_line[digest]
+                if digest == "md5sum":
+                    # duplicate hash as 'md5' too, for BuildInfo naming
+                    files_hashes.setdefault(f_line["name"], {})["md5"] = f_line[digest]
+                    files_hashes[f_line["name"]]["size"] = f_line["size"]
+
+    return files_hashes
+
+
+def patch_checksums(
+    changes_path: Path, klass: Type[Deb822], files_hashes: dict[str, dict[str, str]]
+):
+    """
+    Update file hashes in 'changes' or 'buildinfo' file.
+    """
+    with changes_path.open("rb") as changes_f:
+        changes = klass(changes_f)
+        for digest, section in (
+            ("md5sum", "Files"),  # changes
+            ("md5", "Checksums-Md5"),  # buildinfo
+            ("sha1", "Checksums-Sha1"),
+            ("sha256", "Checksums-Sha256"),
+            ("sha512", "Checksums-Sha512"),
+        ):
+            if section not in changes:
+                continue
+            for f_line in changes[section]:
+                if f_line["name"] not in files_hashes:
+                    continue
+                f_line[digest] = files_hashes[f_line["name"]][digest]
+                f_line["size"] = files_hashes[f_line["name"]]["size"]
+
+    with changes_path.open("wb") as changes_f:
+        changes.dump(changes_f)
+
+
+def main():
+    """
+    Main function
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("orig_dsc_path", type=Path)
+    parser.add_argument("buildinfo_path", type=Path)
+    parser.add_argument("changes_path", type=Path)
+    args = parser.parse_args()
+
+    files_hashes = parse_dsc(args.orig_dsc_path)
+    # get hashes of the dsc itself
+    files_hashes[args.orig_dsc_path.name] = get_checksums(args.orig_dsc_path)
+    patch_checksums(args.buildinfo_path, BuildInfo, files_hashes)
+    files_hashes[args.buildinfo_path.name] = get_checksums(args.buildinfo_path)
+    patch_checksums(args.changes_path, Changes, files_hashes)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -910,6 +910,21 @@ def test_component_build_vm_bullseye(artifacts_dir):
     assert info.get("package-release-name", None) == package_release_name
     assert info.get("package-release-name-full", None) == package_release_name_full
 
+    files = [
+        "python-qasync_0.23.0-1+deb11u1.dsc",
+        "python-qasync_0.23.0-1+deb11u1_amd64.changes",
+        "python-qasync_0.23.0-1+deb11u1_amd64.buildinfo",
+    ]
+    for f in files:
+        file_path = (
+            artifacts_dir / f"components/python-qasync/0.23.0-1/vm-bullseye/build/{f}"
+        )
+        assert file_path.exists()
+        result = subprocess.run(
+            f"dscverify --no-sig-check {file_path}",
+            shell=True,
+        )
+        assert result.returncode == 0
 
 def test_component_sign_vm_bullseye(artifacts_dir):
     env = os.environ.copy()
@@ -950,6 +965,11 @@ def test_component_sign_vm_bullseye(artifacts_dir):
         assert file_path.exists()
         result = subprocess.run(
             f"gpg2 --homedir {keyring_dir} --verify {file_path}",
+            shell=True,
+        )
+        assert result.returncode == 0
+        result = subprocess.run(
+            f"dscverify --no-sig-check {file_path}",
             shell=True,
         )
         assert result.returncode == 0


### PR DESCRIPTION
Some versions of dpkg-source do not produce reproducible output. This
means, dpkg-source output at the 'prep' stage will produce different
output than the dpkg-source call at the 'build' stage. We prefer to keep
original source from 'prep' stage, but the .changes file include
checksums from the build stage. If they don't match, reprepro will
(rightfully) refuse to process the package.
At the time of writting, this issue applies to dpkg-source in Debian
bookworm.

Since this is recurring issue, add permanent workaround by updating
hashes in the changes file to the values from the original source
package.