### PR TITLE
container: use 'mounts' instead of 'volumes'

### DIFF
--- a/qubesbuilder/executors/container.py
+++ b/qubesbuilder/executors/container.py
@@ -175,18 +175,19 @@ class ContainerExecutor(Executor):
                 if self._container_client == "podman":
                     for k, v in environment.copy().items():
                         environment[k] = str(v)
-                if self._container_client == "podman":
-                    volumes = {
-                        "loop-control": {"bind": "/dev/loop-control", "mode": "rw"}
+                mounts = [
+                    {
+                        "type": "bind",
+                        "source": "/dev/loop-control",
+                        "target": "/dev/loop-control",
                     }
-                else:
-                    volumes = ["/dev/loop-control"]  # type: ignore
+                ]
                 container = client.containers.create(
                     image,
                     container_cmd,
                     privileged=True,
                     environment=environment,
-                    volumes=volumes,
+                    mounts=mounts,
                 )
 
                 # Adjust log namespace

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -32,23 +32,15 @@ distributions:
 
 components:
   - builder-rpm:
-      url: https://github.com/fepitre/qubes-builder-rpm
-      branch: builderv2
       packages: False
-      maintainers:
-        - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
   - builder-debian:
-      url: https://github.com/fepitre/qubes-builder-debian
-      branch: builderv2
       packages: False
-      maintainers:
-        - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
   - template-whonix:
-      url: https://github.com/fepitre/qubes-template-whonix
-      branch: builderv2
       packages: False
+      url: https://github.com/Whonix/qubes-template-whonix
+      branch: master
       maintainers:
-        - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
+        - 916B8D99C38EAF5E8ADC7A2A8D66066A2EEACCDA
   - python-qasync:
       url: https://github.com/fepitre/qubes-python-qasync
       branch: builderv2


### PR DESCRIPTION
It fixes newer issue introduced with recent podman API.