### PR TITLE
Fix parsing colons in config values on CLI

### DIFF
--- a/qubesbuilder/cli/cli_main.py
+++ b/qubesbuilder/cli/cli_main.py
@@ -60,9 +60,14 @@ def validate_identifier(identifier):
     raise ValueError(f"Invalid key identifier found: '{identifier}'.")
 
 
-def parse_dict_from_cli(s):
+def parse_dict_from_cli(s, value=None):
     index_dict = None
     index_array = None
+
+    if value is None:
+        # first, consider everything after "=" as value
+        if "=" in s:
+            s, value = s.split("=", 1)
 
     # Determine if split identifier "+" or ":" is present
     if ":" in s:
@@ -97,25 +102,27 @@ def parse_dict_from_cli(s):
         validate_identifier(parsed_identifier)
 
         if split_identifier == ":":
-            if "=" not in remaining_content:
+            if value is None:
                 raise ValueError(f"Cannot find '=' in '{remaining_content}'")
-            result = {parsed_identifier: parse_dict_from_cli(remaining_content)}
+            result = {
+                parsed_identifier: parse_dict_from_cli(remaining_content, value=value)
+            }
         else:
-            result = {parsed_identifier: [parse_dict_from_cli(remaining_content)]}
+            result = {
+                parsed_identifier: [parse_dict_from_cli(remaining_content, value=value)]
+            }
     else:
-        if "=" not in s:
+        if value is None:
             result = s
         else:
-            if s.count("=") != 1:
-                raise ValueError("Too much '=' found.")
-            key, val = s.split("=", 1)
+            key = s
 
             # Validate key
             validate_identifier(key)
 
-            if val.lower() in ("true", "false", "1", "0"):
-                val = str_to_bool(val)
-            result = {key: val}
+            if value.lower() in ("true", "false", "1", "0"):
+                value = str_to_bool(value)
+            result = {key: value}
     return result
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -114,11 +114,6 @@ def test_parse_config_entry_from_array_02():
         parse_config_from_cli(array)
     assert "_" in e.value.args[0]
 
-    array = ["tata:titi:toto=too=much=equals"]
-    with pytest.raises(ValueError) as e:
-        parse_config_from_cli(array)
-    assert "Too much" in e.value.args[0]
-
 
 def test_parse_config_entry_from_array_03():
     array = [
@@ -140,5 +135,25 @@ def test_parse_config_entry_from_array_04():
     parsed_dict = parse_config_from_cli(array)
     expected_dict = {
         "+components": [{"kernel": {"branch": "stable-5.15"}}, "lvm2"],
+    }
+    assert parsed_dict == expected_dict
+
+
+def test_parse_config_entry_from_array_05():
+    array = [
+        "repository-upload-remote-host:iso=remote.host:/remote/dir/",
+    ]
+    parsed_dict = parse_config_from_cli(array)
+    expected_dict = {
+        "repository-upload-remote-host": {"iso": "remote.host:/remote/dir/"},
+    }
+    assert parsed_dict == expected_dict
+
+
+def test_parse_config_entry_from_array_06():
+    array = ["tata:titi:toto=many=equals"]
+    parsed_dict = parse_config_from_cli(array)
+    expected_dict = {
+        "tata": {"titi": {"toto": "many=equals"}},
     }
     assert parsed_dict == expected_dict


### PR DESCRIPTION
Split by "=" first and only then parse dict prefix. Do not consider ":"
or "+" in a value for dict position.

This allows setting URLs or other values with colons in them via CLI.