### PR TITLE
Remove iso-full-online occurences

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -378,7 +378,7 @@ qubes-template-whonix-workstation-16:
     - rm -rf artifacts/cache
     - tree artifacts
 
-installer-iso-full-online:
+installer-iso-online-testing:
   variables:
     KICKSTART_FILE: conf/iso-online-testing.ks
     EXPECT_FAILURE: ""

--- a/example-configs/builder-devel.yml
+++ b/example-configs/builder-devel.yml
@@ -27,7 +27,7 @@ sign-key:
 
 # Path relative to qubesbuilder/plugins/installer
 iso:
-  kickstart: conf/iso-full-online.ks
+  kickstart: conf/iso-online.ks
 
 distributions:
   - host-fc37


### PR DESCRIPTION
Rename remaining occurrences of `iso-full-online` to `iso-online`.

This fixes https://github.com/QubesOS/qubes-issues/issues/8122.