### PR TITLE
docker: bind mount the whole /dev into the container

### DIFF
--- a/dockerfiles/fedora-mock.Dockerfile
+++ b/dockerfiles/fedora-mock.Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y update && \
     dnf install -y createrepo_c debootstrap devscripts dpkg-dev git mock pbuilder \
         which perl-Digest-MD5 perl-Digest-SHA python3-pyyaml e2fsprogs \
         python3-sh rpm-build rpmdevtools wget python3-debian reprepro systemd-udev \
-        tree python3-jinja2-cli pacman m4 asciidoc rsync \
+        tree python3-jinja2-cli pacman m4 asciidoc rsync psmisc \
     && dnf clean all
 
 # Install devtools for Archlinux

--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y update && \
     dnf install -y createrepo_c debootstrap devscripts dpkg-dev git mock pbuilder \
         which perl-Digest-MD5 perl-Digest-SHA python3-pyyaml e2fsprogs \
         python3-sh rpm-build rpmdevtools wget python3-debian reprepro systemd-udev \
-        tree python3-jinja2-cli pacman m4 asciidoc rsync \
+        tree python3-jinja2-cli pacman m4 asciidoc rsync psmisc \
     && dnf clean all
 
 # Install devtools for Archlinux

--- a/qubesbuilder/executors/container.py
+++ b/qubesbuilder/executors/container.py
@@ -180,7 +180,7 @@ class ContainerExecutor(Executor):
                         "type": "bind",
                         "source": "/dev/loop-control",
                         "target": "/dev/loop-control",
-                    }
+                    },
                 ]
                 container = client.containers.create(
                     image,

--- a/qubesbuilder/plugins/template/scripts/prepare-image
+++ b/qubesbuilder/plugins/template/scripts/prepare-image
@@ -44,6 +44,13 @@ export INSTALL_DIR LC_ALL IMG
 # ------------------------------------------------------------------------------
 # Prepare for mount
 # ------------------------------------------------------------------------------
+
+# docker has tmpfs on /dev with copied content from host, it doesn't update
+# when loop0p3 shows up; mount devmpfs to avoid this issue
+if [ "$(df -T /dev | tail -1 |cut -f 1 -d ' ')" = "tmpfs" ]; then
+    mount -t devtmpfs none /dev
+fi
+
 DIST_TO_STR="${DIST_CODENAME}+${TEMPLATE_FLAVOR}"
 if [ ${#TEMPLATE_OPTIONS} -gt 0 ]; then
     DIST_TO_STR="${DIST_TO_STR} (options: ${TEMPLATE_OPTIONS[*]})"


### PR DESCRIPTION
Building templates requires that new loop devices (created with losetup
-P) appear inside the container. It is not the case by default in
docker. Fix this by bind-mounting the whole /dev into the container. It
is a privileged container anyway, so it doesn't change much.

Details at https://github.com/moby/moby/issues/27886