### PR TITLE
archlinux: fix handling current-testing setting

### DIFF
--- a/qubesbuilder/plugins/chroot_archlinux/conf/pacman.conf.j2
+++ b/qubesbuilder/plugins/chroot_archlinux/conf/pacman.conf.j2
@@ -63,7 +63,7 @@ Server = file:///builder/repository/pkgs
 Server = https://archlinux.qubes-os.org/r{{use_qubes_repo_version}}/current/vm/archlinux/pkgs
 {% endif %}
 
-{% if use_qubes_repo_testing == "1" %}
+{% if use_qubes_repo_testing %}
 [qubes-r{{use_qubes_repo_version}}-current-testing]
 Server = https://archlinux.qubes-os.org/r{{use_qubes_repo_version}}/current-testing/vm/archlinux/pkgs
 {% endif %}


### PR DESCRIPTION
Treat use_qubes_repo_testing as boolean (the python part will set it
only if it's true in python), not a string specifically set to "1".