### PR TITLE
installer: include locally built templates in the ISO repository

### DIFF
--- a/qubesbuilder/cli/cli_installer.py
+++ b/qubesbuilder/cli/cli_installer.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import click
 
 from qubesbuilder.cli.cli_base import aliased_group, ContextObj
@@ -6,6 +8,7 @@ from qubesbuilder.common import STAGES, STAGES_ALIAS
 from qubesbuilder.config import Config
 from qubesbuilder.plugins.installer import InstallerPlugin
 from qubesbuilder.pluginmanager import PluginManager
+from qubesbuilder.template import QubesTemplate
 
 
 @aliased_group("installer", chain=True)
@@ -20,6 +23,7 @@ def _installer_stage(
     manager: PluginManager,
     stage_name: str,
     iso_timestamp: str = None,
+    templates: List[QubesTemplate] = [],
 ):
     """
     Generic function to trigger stage for a template component
@@ -35,7 +39,9 @@ def _installer_stage(
         raise CliError("One and only one host distribution must be provided.")
 
     dist = host_distributions[0]
-    installer_plugin = InstallerPlugin(dist=dist, config=config, manager=manager)
+    installer_plugin = InstallerPlugin(
+        dist=dist, config=config, manager=manager, templates=templates
+    )
     installer_plugin.run(stage=stage_name, iso_timestamp=iso_timestamp)
 
 
@@ -43,13 +49,23 @@ def _installer_stage(
 @click.pass_obj
 def _all_installer_stage(obj: ContextObj):
     for s in STAGES:
-        _installer_stage(config=obj.config, manager=obj.manager, stage_name=s)
+        _installer_stage(
+            config=obj.config,
+            manager=obj.manager,
+            templates=obj.templates,
+            stage_name=s,
+        )
 
 
 @installer.command()
 @click.pass_obj
 def fetch(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="fetch")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="fetch",
+    )
 
 
 @installer.command()
@@ -65,49 +81,85 @@ def prep(obj: ContextObj, iso_timestamp: str):
         manager=obj.manager,
         stage_name="prep",
         iso_timestamp=iso_timestamp,
+        templates=obj.templates,
     )
 
 
 @installer.command()
 @click.pass_obj
 def build(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="build")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="build",
+    )
 
 
 @installer.command()
 @click.pass_obj
 def post(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="post")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="post",
+    )
 
 
 @installer.command()
 @click.pass_obj
 def verify(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="verify")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="verify",
+    )
 
 
 @installer.command()
 @click.pass_obj
 def sign(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="sign")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="sign",
+    )
 
 
 @installer.command()
 @click.pass_obj
 def publish(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="publish")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="publish",
+    )
 
 
 @installer.command()
 @click.pass_obj
 def upload(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="upload")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="upload",
+    )
 
 
 @installer.command()
 @click.pass_obj
 def init_cache(obj: ContextObj):
-    _installer_stage(config=obj.config, manager=obj.manager, stage_name="init-cache")
+    _installer_stage(
+        config=obj.config,
+        manager=obj.manager,
+        templates=obj.templates,
+        stage_name="init-cache",
+    )
 
 
 installer.add_command(init_cache, name="init-cache")

--- a/qubesbuilder/cli/cli_repository.py
+++ b/qubesbuilder/cli/cli_repository.py
@@ -272,7 +272,7 @@ def _check_release_status_for_template(config, manager, templates):
             for repo_name in TEMPLATE_REPOSITORIES:
                 days = 0
                 if plugin.is_published(repository=repo_name):
-                    publish_info = plugin.get_artifacts_info(stage="publish")
+                    publish_info = plugin.get_template_artifacts_info(stage="publish")
                     for repo in publish_info.get("repository-publish", []):
                         if repo["name"] == repo_name:
                             publish_date = datetime.datetime.strptime(
@@ -295,7 +295,7 @@ def _check_release_status_for_template(config, manager, templates):
             raise CliError(f"{template}: Failed to process status ({str(e)}).")
 
         if not found:
-            if plugin.get_artifacts_info(stage="build"):
+            if plugin.get_template_artifacts_info(stage="build"):
                 status = "built, not released"
                 set_template_tag = True
             else:


### PR DESCRIPTION
Do not require downloading them from online repository. Especially, this 
makes the default kickstart config useful, otherwise it results in 
template-less ISO.