### PR TITLE
Improve query-builtrpms

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,6 +214,7 @@ pytest-cli-template:
   script:
     - cp tests/builder-ci.yml builder.yml
     - sed -i 's/docker/qubes/' builder.yml
+    - "sed -i 's/user: gitlab-runner/user: user/; s/group: gitlab-runner/group: user/' builder.yml"
     - ./qb -d "${CI_JOB_NAME#qubes-}" --option executor:type=qubes --option executor:options:dispvm=builder-dvm ${QB_EXTRA_ARGS} package all
   after_script:
     - rm -rf artifacts/cache

--- a/qubesbuilder/plugins/source_rpm/scripts/query-builtrpms
+++ b/qubesbuilder/plugins/source_rpm/scripts/query-builtrpms
@@ -40,10 +40,14 @@ if [ "$(type -t set_rpm_defines)" = "function" ]; then
     set_rpm_defines "$DIST_TAG"
 fi
 
-RPM_OPS=("${rpm_defines[@]}" --nodebuginfo)
+RPM_OPS=("${rpm_defines[@]}")
 
-# Get builtrpms from rpmspec without debuginfo
+# Manually add debuginfo packages in addition to standard query, and then
+# filter duplicates. This way both static (defined expliticly in spec) and
+# dynamic ones are handled.
 # see https://github.com/rpm-software-management/rpm/issues/1878
+{
 rpmspec --builtrpms "${RPM_OPS[@]}" -q --qf '%{name}-%{version}-%{release}.%{arch}.rpm\n' "${SPEC_FILE}"
-rpmspec --builtrpms "${RPM_OPS[@]}" -q --qf '%{name}-debuginfo-%{version}-%{release}.%{arch}.rpm\n' "${SPEC_FILE}" | grep -v -- '-devel' 2>/dev/null || true
-rpmspec --builtrpms "${RPM_OPS[@]}" -q --qf '%{name}-debugsource-%{version}-%{release}.%{arch}.rpm\n' "${SPEC_FILE}" | grep -v -- '-devel' 2>/dev/null || true
+rpmspec --builtrpms "${RPM_OPS[@]}" -q --qf '%{name}-debuginfo-%{version}-%{release}.%{arch}.rpm\n' "${SPEC_FILE}" | grep -v -- '-devel\|-debuginfo-debuginfo\|-debugsource-debuginfo' 2>/dev/null || true
+rpmspec --builtrpms "${RPM_OPS[@]}" -q --qf '%{name}-debugsource-%{version}-%{release}.%{arch}.rpm\n' "${SPEC_FILE}" | grep -v -- '-devel\|-debuginfo-debugsource\|-debugsource-debugsource' 2>/dev/null || true
+} | sort | uniq


### PR DESCRIPTION
This fixes the grub2 package, where the main 'grub2' is not built, but
grub2-debuginfo and grub2-debugsource are. Now they are properly
enumerated.