### PR TITLE
installer: add EFI partition as GPT

### DIFF
--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -140,6 +140,7 @@ iso-installer-mkisofs:
 		-partition_offset 16 \
 		-append_partition 2 C12A7328-F81F-11D2-BA4B-00A0C93EC93B $(BASE_DIR)/os/images/efiboot.img \
 		-iso_mbr_part_type EBD0A0A2-B9E5-4433-87C0-68B6B72699C7 \
+		-appended_part_as_gpt \
 		-c boot.cat --boot-catalog-hide \
 		-b images/eltorito.img \
 		-no-emul-boot -boot-load-size 4 -boot-info-table --grub2-boot-info \


### PR DESCRIPTION
Make the EFI partition as GPT. For UEFI, the partition table type
matters, it should be GPT (even though MBR does work with some
firmware). This setting will produce protective MBR instead of actual
partition table there, but that's okay - the bootsector is still there,
and grub can handle GPT just fine.

Fixes QubesOS/qubes-issues#8395