### PR TITLE
local: cleaup does need root access in some cases after all

### DIFF
--- a/qubesbuilder/executors/local.py
+++ b/qubesbuilder/executors/local.py
@@ -168,10 +168,25 @@ class LocalExecutor(Executor):
             if self._temporary_dir.exists() and self._clean:
                 try:
                     subprocess.run(
-                        ["rm", "-rf", "--", self._temporary_dir],
+                        [
+                            "sudo",
+                            "--non-interactive",
+                            "rm",
+                            "-rf",
+                            "--",
+                            self._temporary_dir,
+                        ],
                         check=True,
                     )
                 except subprocess.CalledProcessError as e:
-                    raise ExecutorError(
-                        f"Failed to clean executor temporary directory: {str(e)}"
-                    )
+                    try:
+                        # retry without sudo, as local executor for many
+                        # actions doesn't really need it
+                        subprocess.run(
+                            ["rm", "-rf", "--", self._temporary_dir],
+                            check=True,
+                        )
+                    except subprocess.CalledProcessError as e:
+                        raise ExecutorError(
+                            f"Failed to clean executor temporary directory: {str(e)}"
+                        )


### PR DESCRIPTION
If local executor is used for actual build with mock or pbuilder, it
will leave behind a bunch of root-owned files. Try to use sudo when
cleaning it up, and fallback to non-sudo call only if sudo one fails
(usually because the user doesn't have passwordless sudo access).

Partially reverts 39b72fe "local: no need to chown or remove as root
anymore"