### PR TITLE
Use partition layout on the iso as isohybrid did

### DIFF
--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -147,6 +147,7 @@ iso-installer-mkisofs:
 		-eltorito-alt-boot \
 		-e '--interval:appended_partition_2:all::' -no-emul-boot \
 		-graft-points \
+		-part_like_isohybrid \
 		.=$(BASE_DIR)/os \
 		boot/grub2/i386-pc=/usr/lib/grub/i386-pc
 	/usr/bin/implantisomd5 $(BASE_DIR)/iso/$(ISO_NAME).iso


### PR DESCRIPTION
Some legacy firmware are not happy about protective MBR partition table
(even if the boot sector is there). Use isohybrid partition layout -
which presents actual partitions in MBR table "mirrored" from GPT.

Fixes QubesOS/qubes-issues#8462