### PR TITLE
fix: arch-install-scripts package name

### DIFF
--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y update && \
     dnf install -y dnf-plugins-core createrepo_c debootstrap devscripts dpkg-dev git mock pbuilder \
         which perl-Digest-MD5 perl-Digest-SHA python3-pyyaml e2fsprogs \
         python3-sh rpm-build rpmdevtools wget python3-debian reprepro systemd-udev \
-        tree python3-jinja2-cli pacman m4 asciidoc rsync psmisc zstd archlinux-keyring debian-keyring arch-install-script \
+        tree python3-jinja2-cli pacman m4 asciidoc rsync psmisc zstd archlinux-keyring debian-keyring arch-install-scripts \
     && dnf clean all
 
 # Install devtools for Archlinux


### PR DESCRIPTION
`arch-install-scripts` was misspelled in the `dockerfiles/fedora.Dockerfile` (missing an 's'), but correctly spelled in `dockerfiles/fedora-mock.Dockerfile`.