### PR TITLE
Use the unconfined qfile-unpacker

### DIFF
--- a/qubesbuilder/executors/qubes.py
+++ b/qubesbuilder/executors/qubes.py
@@ -92,11 +92,17 @@ class QubesExecutor(Executor):
 
         dst.mkdir(parents=True, exist_ok=True)
 
+        old_unpacker_path = "/usr/lib/qubes/qfile-unpacker"
+        new_unpacker_path = "/usr/bin/qfile-unpacker"
+        if os.path.exists(new_unpacker_path):
+            unpacker_path = new_unpacker_path
+        else:
+            unpacker_path = old_unpacker_path
         cmd = [
             "/usr/lib/qubes/qrexec-client-vm",
             vm,
             f"qubesbuilder.FileCopyOut+{str(src).replace('/', '__')}",
-            "/usr/lib/qubes/qfile-unpacker",
+            unpacker_path,
             str(os.getuid()),
             str(dst),
         ]

--- a/rpc/qubesbuilder.FileCopyIn
+++ b/rpc/qubesbuilder.FileCopyIn
@@ -4,4 +4,9 @@ set -e
 
 sudo bash -c "mkdir -p /builder/incoming && chown -R user:user /builder"
 
-exec /usr/lib/qubes/qfile-unpacker "$(id -u user)" "/builder/incoming"
+id=$(id -u user)
+
+if [ -x /usr/lib/qubes/qfile-unpacker ]; then
+    PATH=${PATH+"$PATH:"}/usr/lib/qubes
+fi
+exec qfile-unpacker "$id" "/builder/incoming"


### PR DESCRIPTION
This allows builderv2 to work with SELinux enforcing.

Fixes https://github.com/QubesOS/qubes-issues/issues/8760