### PR TITLE
Allow using custom comps file

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ Options available in `builder.yml`:
 
 - `iso: Dict`:
   - `kickstart: str` --- Image installer kickstart. The path usually points at a file in `qubesbuilder/plugins/installer`, in a `conf/` directory - example value: `conf/iso-online-testing.ks`. To use path outside of that directory, either set absolute path, or a path starting with `./` (path relative to qubes-builderv2 directory).
+  - `comps: str` --- Image installer groups (comps) file. The path usually points at a file in `qubesbuilder/plugins/installer`, in a `meta-packages/comps/` directory - example value: `meta-packages/comps/comps-dom0.xml`. To use path outside of that directory, either set absolute path, or a path starting with `./` (path relative to qubes-builderv2 directory).
   - `flavor: str` --- Image name will be named as `Qubes-<iso-version>-<iso-flavor>-<arch>.iso`.
   - `use-kernel-latest: bool` --- If True, use `kernel-latest` when building installer runtime and superseed `kernel` in the installation. It allows to boot installer and QubesOS with the latest drivers provided by stable kernels and not only long term supported ones by default.
   - `version: str` --- Define specific version to embed, by default current date is used.

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -104,6 +104,7 @@ class Config:
     template_root_size: Union[str, property]             = property(lambda self: self.get("template-root-size", "20G"))
     template_root_with_partitions: Union[bool, property] = property(lambda self: self.get("template-root-with-partitions", True))
     installer_kickstart: Union[str, property]            = property(lambda self: self.get("iso", {}).get("kickstart", "conf/qubes-kickstart.cfg"))
+    installer_comps: Union[str, property]                = property(lambda self: self.get("iso", {}).get("comps", "meta-packages/comps/comps-dom0.xml"))
     iso_version: Union[str, property]                    = property(lambda self: self.get("iso", {}).get("version", ""))
     iso_flavor: Union[str, property]                     = property(lambda self: self.get("iso", {}).get("flavor", ""))
     iso_use_kernel_latest: Union[bool, property]         = property(lambda self: self.get("iso", {}).get("use-kernel-latest", False))

--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -26,6 +26,7 @@ INSTALLER_DIR ?= $(PLUGINS_DIR)/installer
 INSTALLER_KICKSTART ?= $(INSTALLER_DIR)/conf/qubes-kickstart.cfg
 CREATEREPO := $(shell which createrepo_c createrepo 2>/dev/null |head -1)
 ISO_VERSION ?= $(shell date +%Y%m%d)
+COMPS_FILE ?= $(INSTALLER_DIR)/meta-packages/comps/comps-dom0.xml
 
 ifneq (,$(ISO_FLAVOR))
 ISO_NAME := Qubes-$(ISO_VERSION)-$(ISO_FLAVOR)-x86_64
@@ -70,10 +71,7 @@ iso-prepare:
 
 	# Copy the comps file
 	mkdir -p $(TMP_DIR)
-	cp $(INSTALLER_DIR)/meta-packages/comps/comps-dom0.xml $(TMP_DIR)/comps.xml
-	if [ "$(ISO_USE_KERNEL_LATEST)" == 1 ]; then \
-		sed -i 's#optional">kernel-latest#mandatory">kernel-latest#g' $(TMP_DIR)/comps.xml; \
-	fi;
+	cp $(COMPS_FILE) $(TMP_DIR)/comps.xml
 
 	mkdir /tmp/qubes-installer
 	mount --bind $(INSTALLER_DIR) /tmp/qubes-installer


### PR DESCRIPTION
This allows building custom ISO with different package set, like,
different desktop environment, some extra packages. When group is set as
user visible, it's also selectable during installation.
Implement it similar to the kickstart option - by default use relative
path to qubesbuilder/plugins/installer (where other installer-related
paths are), but support also absolute paths or paths starting with `./`
as relative to the builder top dir.