### PR TITLE
installer: revert change to isohybrid

### DIFF
--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -135,8 +135,10 @@ iso-installer-mkisofs:
 	xorrisofs -o $(BASE_DIR)/iso/$(ISO_NAME).iso \
 		-R -J -V $(ISO_VOLID) \
 		--grub2-mbr /usr/lib/grub/i386-pc/boot_hybrid.img \
+		--mbr-force-bootable \
+		--gpt-iso-bootable \
 		-partition_offset 16 \
-		-append_partition 2 C12A7328-F81F-11D2-BA4B-00A0C93EC93B $(BASE_DIR)/os/images/efiboot.img \
+		-append_partition 2 0xef $(BASE_DIR)/os/images/efiboot.img \
 		-iso_mbr_part_type EBD0A0A2-B9E5-4433-87C0-68B6B72699C7 \
 		-appended_part_as_gpt \
 		-c boot.cat --boot-catalog-hide \
@@ -145,7 +147,6 @@ iso-installer-mkisofs:
 		-eltorito-alt-boot \
 		-e '--interval:appended_partition_2:all::' -no-emul-boot \
 		-graft-points \
-		-part_like_isohybrid \
 		.=$(BASE_DIR)/os \
 		boot/grub2/i386-pc=/usr/lib/grub/i386-pc
 	/usr/bin/implantisomd5 $(BASE_DIR)/iso/$(ISO_NAME).iso


### PR DESCRIPTION
The isohybrid method produces unusual partition layout, where GPT
doesn't match MBR partition table, but also MBR isn't really
"protective MBR" layout. Some firmware consider it broken and do not
boot properly from this media. Fdisk also doesn't detect GPT properly
(but gdisk does).

The main reason for switching to isohybrid was to have a "active" MBR
partition for legacy boot (again, some firmware look if any partition is
marked as "active", even if the actual boot code is in the MBR
itself). This can be achieved with a standard GPT + protective MBR
layout by using --mbr-force-bootable option - it adds a small partition
(covering actual MBR boot code) that is marked as "active".
Similarly add --gpt-iso-bootable option to mark some GPT partition as
legacy bootable, per xorrisofs man page:

    This bit is specified as "Legacy BIOS  bootable"  but  its  true
    significance  is  unclear.   Some  GPT-aware  BIOS  might
    want  to  see it in some partition.

Fixes QubesOS/qubes-issues#8717