### PR TITLE
Add Debian trixie (13) support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -319,6 +319,9 @@ cache-vm-bullseye:
 cache-vm-bookworm:
   extends: .init_cache_job
 
+cache-vm-trixie:
+  extends: .init_cache_job
+
 cache-vm-archlinux:
   extends: .init_cache_job
 

--- a/qubesbuilder/plugins/chroot_deb/keys/trixie-debian-archive-keyring.gpg
+++ b/qubesbuilder/plugins/chroot_deb/keys/trixie-debian-archive-keyring.gpg
@@ -1,0 +1,1 @@
+bookworm-debian-archive-keyring.gpg

--- a/qubesbuilder/plugins/chroot_deb/pbuilder/pbuilderrc
+++ b/qubesbuilder/plugins/chroot_deb/pbuilder/pbuilderrc
@@ -14,7 +14,7 @@ LOGLEVEL=I
 USECOLORS=auto
 
 case ${DISTRIBUTION} in
-    buster|bullseye|bookworm|sid|experimental)
+    buster|bullseye|bookworm|trixie|sid|experimental)
         DIST_VENDOR=debian
         MIRRORSITE=https://deb.debian.org/debian
         ;;
@@ -61,7 +61,7 @@ BUILDRESULT="@BUILDER_DIR@/pbuilder/results"
 # components on Debian use "main contrib non-free" and on Ubuntu "main
 # restricted universe multiverse"
 case ${DISTRIBUTION} in
-    buster|bullseye|bookworm|sid|experimental)
+    buster|bullseye|bookworm|trixie|sid|experimental)
         COMPONENTS="main"
         ;;
     bionic|focal|jammy|lunar)


### PR DESCRIPTION
There is no new signig key yet, repository is still signed with the
Debian 12 key.

QubesOS/qubes-issues#8841