### PR TITLE
Fix building the first arch package

### DIFF
--- a/qubesbuilder/plugins/build_archlinux/scripts/update-local-repo.sh
+++ b/qubesbuilder/plugins/build_archlinux/scripts/update-local-repo.sh
@@ -26,7 +26,11 @@ chroot_cmd() {
 mkdir -p "$PKGS_DIR"
 if [ ! -f "${PKGS_DIR}/qubes.db" ]; then
     echo "  -> Repo '${PKGS_DIR}' appears empty; initialising..."
-    chroot_cmd repo-add pkgs/qubes.db.tar.gz
+    # repo-add cannot create empty db anymore, do it manually
+    bsdtar -cf - -T /dev/null | gzip > "${PKGS_DIR}/qubes.db.tar.gz"
+    ln -s qubes.db.tar.gz "${PKGS_DIR}/qubes.db"
+    bsdtar -cf - -T /dev/null | gzip > "${PKGS_DIR}/qubes.files.tar.gz"
+    ln -s qubes.files.tar.gz "${PKGS_DIR}/qubes.files"
 fi
 
 set -e

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
@@ -107,6 +107,9 @@ def main(args):
         gpg_client = gpg
     else:
         raise ValueError("Cannot find GnuPG or GnuPG-compatible Sequoia Chameleon.")
+    # XXX temporarily switch back to GnuPG, see
+    # https://github.com/QubesOS/qubes-issues/issues/9012#issuecomment-2026665655
+    gpg_client = gpg
 
     # Validity check on provided maintainers
     for maintainer in maintainers:


### PR DESCRIPTION
Local repository on the first build is empty, but it still needs to have
metadata (qubes.db, qubes.files). `repo-add` used to create empty
metadata when called without any package, but since
https://gitlab.archlinux.org/pacman/pacman/-/commit/f91fa546f65af9ca7cdbe2b419c181df609969b7
it doesn't do it anymore. Since creating empty metadata is trivial
(based on the repo-add code), do that in the update-local-repo.sh script
directly.

This issue was especially hitting the CI, where every build is the first
package.