### PR TITLE
Allow partially overriding "git" config section too

### DIFF
--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -148,6 +148,7 @@ class Config:
                     "+components",
                     "+stages",
                     "+plugins",
+                    "+git",
                 ):
                     combined_conf.setdefault(key, [])
                     combined_conf[key] += data[key]
@@ -170,6 +171,7 @@ class Config:
                 "+components",
                 "+stages",
                 "+plugins",
+                "+git",
             ):
                 combined_conf.setdefault(key, [])
                 combined_conf[key] += conf[key]
@@ -185,6 +187,7 @@ class Config:
                     "components",
                     "stages",
                     "plugins",
+                    "git",
                 ):
                     if isinstance(combined_conf[key], dict) and isinstance(
                         options[key], dict


### PR DESCRIPTION
This allows changing just some settings (like default branch, or git URL
prefix) on top of included default config, without the need to copy the
whole section.

Fixes what we use in CI:

    include:
     - example-configs/qubes-os-r4.2.yml

    git:
      branch: main

Now the maintainers from the default config will be preserved.