### PR TITLE
Set human readable pacman output : no progress bar in scripts

### DIFF
--- a/qubesbuilder/plugins/build_archlinux/scripts/update-local-repo.sh
+++ b/qubesbuilder/plugins/build_archlinux/scripts/update-local-repo.sh
@@ -49,8 +49,8 @@ chroot_cmd sed "s/^ *CheckSpace/#CheckSpace/g" -i /etc/pacman.conf
 
 # Update archlinux keyring first so that Archlinux can be updated even after a long time
 chroot_cmd /bin/sh -c \
-    "http_proxy='${REPO_PROXY}' pacman -Sy --noconfirm archlinux-keyring"
+    "http_proxy='${REPO_PROXY}' pacman -Sy --noconfirm --noprogressbar archlinux-keyring"
 
 # Now update system
 chroot_cmd /bin/sh -c \
-    "http_proxy='${REPO_PROXY}' pacman -Syu --noconfirm"
+    "http_proxy='${REPO_PROXY}' pacman -Syu --noconfirm --noprogressbar"


### PR DESCRIPTION
Add `--noprogressbar` to pacman to avoid unreadable progressbar in the logs.
Fixes : QubesOS/qubes-issues/issues/9172