### PR TITLE
Use sqv for file verification, second attempt

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -347,11 +347,6 @@ podman-vm-fc38:
   needs:
     - cache-vm-fc38
 
-podman-vm-centos-stream8:
-  extends: .component_podman_job
-  needs:
-    - cache-vm-centos-stream8
-
 #podman-vm-bookworm:
 #  extends: .component_podman_job
 
@@ -366,11 +361,6 @@ docker-vm-fc38:
   extends: .component_docker_job
   needs:
     - cache-vm-fc38
-
-docker-vm-centos-stream8:
-  extends: .component_docker_job
-  needs:
-    - cache-vm-centos-stream8
 
 docker-vm-bookworm:
   extends: .component_docker_job
@@ -409,11 +399,6 @@ qubes-vm-fc38:
   needs:
     - cache-vm-fc38
 
-qubes-vm-centos-stream8:
-  extends: .component_qubes_job
-  needs:
-    - cache-vm-centos-stream8
-
 qubes-vm-bookworm:
   extends: .component_qubes_job
   needs:
@@ -431,11 +416,6 @@ local-vm-fc38:
   needs:
     - cache-vm-fc38
 
-local-vm-centos-stream8:
-  extends: .component_local_job
-  needs:
-    - cache-vm-centos-stream8
-
 local-vm-bookworm:
   extends: .component_local_job
   needs:
@@ -446,9 +426,6 @@ local-vm-bookworm:
 #
 
 qubes-template-fedora-38-xfce:
-  extends: .template_qubes_job
-
-qubes-template-centos-stream-8:
   extends: .template_qubes_job
 
 qubes-template-debian-12:

--- a/qubesbuilder/plugins/fetch/scripts/sequoia-crypto-policy.toml
+++ b/qubesbuilder/plugins/fetch/scripts/sequoia-crypto-policy.toml
@@ -1,0 +1,4 @@
+[hash_algorithms]
+sha1.second_preimage_resistance = "always"
+sha1.collision_resistance = "never"
+

--- a/qubesbuilder/plugins/fetch/scripts/verify-file
+++ b/qubesbuilder/plugins/fetch/scripts/verify-file
@@ -123,11 +123,17 @@ elif [ -n "${UNTRUSTED_SIGNATURE_FILE}" ] && [ -n "${PUBKEY_FILE}" ]; then
         sq dearmor --output "$keyring_dir/keyring.gpg" "$keyring_dir/keyring"
     fi
 
-    # Verify file
-    # Temporarily switch back to GnuPG, too many keys are rejected by sqv :/
+    # Verify file, use sequoia if >= 1.2.0 (for crypto policy support),
+    # otherwise gpg
     # https://gitlab.com/sequoia-pgp/sequoia-sqv/-/issues/4
-    #sqv --keyring "$keyring_dir/keyring" "${UNTRUSTED_SIGNATURE_FILE}" "${UNTRUSTED_FILE}"
-    gpgv --keyring "$keyring_dir/keyring.gpg" "${UNTRUSTED_SIGNATURE_FILE}" "${UNTRUSTED_FILE}"
+    sqv_version=$(sqv --version || :)
+    if printf "%s\n" "sqv 1.2.0" "$sqv_version" | sort -VC; then
+        script_dir=$(dirname "$0")
+        export SEQUOIA_CRYPTO_POLICY=$script_dir/sequoia-crypto-policy.toml
+        sqv --keyring "$keyring_dir/keyring" "${UNTRUSTED_SIGNATURE_FILE}" "${UNTRUSTED_FILE}"
+    else
+        gpgv --keyring "$keyring_dir/keyring.gpg" "${UNTRUSTED_SIGNATURE_FILE}" "${UNTRUSTED_FILE}"
+    fi
 
     # Remove 'untrusted_' prefix
     mv "${UNTRUSTED_SIGNATURE_FILE}" "${OUTPUT_DIR}/${SIGNATURE_FILE_NAME}"

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -77,7 +77,7 @@ components:
       branch: v0.23.0-2
   - core-vchan-xen
   - core-qrexec:
-      branch: v4.2.4
+      branch: v4.2.18
   - desktop-linux-xfce4-xfwm4:
       branch: v4.16.1-3
   - app-linux-split-gpg:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,20 +305,20 @@ def test_component_host_fc37_prep(artifacts_dir):
 
     with open(
         artifacts_dir
-        / "components/core-qrexec/4.2.4-1/host-fc37/prep/rpm_spec_qubes-qrexec.spec.prep.yml"
+        / "components/core-qrexec/4.2.18-1/host-fc37/prep/rpm_spec_qubes-qrexec.spec.prep.yml"
     ) as f:
         info = yaml.safe_load(f.read())
 
     rpms = {
-        "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debugsource-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debugsource-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
     }
-    srpm = "qubes-core-qrexec-4.2.4-1.fc37.src.rpm"
+    srpm = "qubes-core-qrexec-4.2.18-1.fc37.src.rpm"
 
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
@@ -326,16 +326,16 @@ def test_component_host_fc37_prep(artifacts_dir):
 
     with open(
         artifacts_dir
-        / "components/core-qrexec/4.2.4-1/host-fc37/prep/rpm_spec_qubes-qrexec-dom0.spec.prep.yml"
+        / "components/core-qrexec/4.2.18-1/host-fc37/prep/rpm_spec_qubes-qrexec-dom0.spec.prep.yml"
     ) as f:
         info = yaml.safe_load(f.read())
 
     rpms = {
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
     }
-    srpm = "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm"
+    srpm = "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm"
 
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
@@ -356,21 +356,21 @@ def test_component_host_fc37_build(artifacts_dir):
 
     with open(
         artifacts_dir
-        / "components/core-qrexec/4.2.4-1/host-fc37/build/rpm_spec_qubes-qrexec.spec.build.yml"
+        / "components/core-qrexec/4.2.18-1/host-fc37/build/rpm_spec_qubes-qrexec.spec.build.yml"
     ) as f:
         info = yaml.safe_load(f.read())
 
     rpms = {
-        "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
     }
-    srpm = "qubes-core-qrexec-4.2.4-1.fc37.src.rpm"
+    srpm = "qubes-core-qrexec-4.2.18-1.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.4" / rpm).exists()
+        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
 
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
@@ -378,19 +378,19 @@ def test_component_host_fc37_build(artifacts_dir):
 
     with open(
         artifacts_dir
-        / "components/core-qrexec/4.2.4-1/host-fc37/build/rpm_spec_qubes-qrexec-dom0.spec.build.yml"
+        / "components/core-qrexec/4.2.18-1/host-fc37/build/rpm_spec_qubes-qrexec-dom0.spec.build.yml"
     ) as f:
         info = yaml.safe_load(f.read())
 
     rpms = {
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
     }
-    srpm = "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm"
+    srpm = "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.4" / rpm).exists()
+        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
 
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
@@ -399,7 +399,7 @@ def test_component_host_fc37_build(artifacts_dir):
     # buildinfo
     assert (
         artifacts_dir
-        / "components/core-qrexec/4.2.4-1/host-fc37/build/rpm/qubes-core-qrexec-4.2.4-1.fc37.x86_64.buildinfo"
+        / "components/core-qrexec/4.2.18-1/host-fc37/build/rpm/qubes-core-qrexec-4.2.18-1.fc37.x86_64.buildinfo"
     ).exists()
 
 
@@ -408,7 +408,7 @@ def test_component_host_fc37_sign(artifacts_dir):
 
     buildinfo = (
         artifacts_dir
-        / "components/core-qrexec/4.2.4-1/host-fc37/build/rpm/qubes-core-qrexec-4.2.4-1.fc37.x86_64.buildinfo"
+        / "components/core-qrexec/4.2.18-1/host-fc37/build/rpm/qubes-core-qrexec-4.2.18-1.fc37.x86_64.buildinfo"
     )
     buildinfo_number_lines = len(buildinfo.read_text(encoding="utf8").splitlines())
 
@@ -439,21 +439,21 @@ def test_component_host_fc37_sign(artifacts_dir):
     assert dbpath.exists()
 
     rpms = [
-        "qubes-core-qrexec-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
     ]
     for rpm in rpms:
         rpm_path = (
             artifacts_dir
-            / f"components/core-qrexec/4.2.4-1/host-fc37/{f'prep/{rpm}' if rpm.endswith('.src.rpm') else f'build/rpm/{rpm}'}"
+            / f"components/core-qrexec/4.2.18-1/host-fc37/{f'prep/{rpm}' if rpm.endswith('.src.rpm') else f'build/rpm/{rpm}'}"
         )
         assert rpm_path.exists()
         result = subprocess.run(
@@ -497,30 +497,30 @@ def test_component_host_fc37_publish(artifacts_dir):
         )
 
         rpms = {
-            "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
         }
-        srpm = "qubes-core-qrexec-4.2.4-1.fc37.src.rpm"
+        srpm = "qubes-core-qrexec-4.2.18-1.fc37.src.rpm"
 
         rpms_dom0 = {
-            "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
         }
-        srpm_dom0 = "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm"
+        srpm_dom0 = "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm"
 
         with open(
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
         ) as f:
             info = yaml.safe_load(f.read())
 
         with open(
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
         ) as f:
             info_dom0 = yaml.safe_load(f.read())
 
@@ -549,13 +549,13 @@ def test_component_host_fc37_publish(artifacts_dir):
         )
         with open(
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
         ) as f:
             info = yaml.safe_load(f.read())
 
         with open(
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
         ) as f:
             info_dom0 = yaml.safe_load(f.read())
 
@@ -584,11 +584,11 @@ def test_component_host_fc37_publish(artifacts_dir):
         fake_time = (datetime.utcnow() - timedelta(days=7)).strftime("%Y%m%d%H%M")
         publish_file = (
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
         )
         publish_dom0_file = (
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
         )
 
         for r in info["repository-publish"]:
@@ -662,16 +662,16 @@ def test_component_host_fc37_publish(artifacts_dir):
         ).exists()
 
     rpms = [
-        "qubes-core-qrexec-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
     ]
 
     # Check that packages are in the published repository
@@ -718,20 +718,20 @@ repository-upload-remote-host:
         )
 
         rpms = {
-            "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
         }
-        srpm = "qubes-core-qrexec-4.2.4-1.fc37.src.rpm"
+        srpm = "qubes-core-qrexec-4.2.18-1.fc37.src.rpm"
 
         rpms_dom0 = {
-            "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
         }
-        srpm_dom0 = "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm"
+        srpm_dom0 = "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm"
 
         for rpm in itertools.chain([srpm_dom0], rpms_dom0, rpms, [srpm]):
             assert (
@@ -812,16 +812,16 @@ def test_component_host_fc37_sign_skip(artifacts_dir):
         ).decode()
 
     rpms = [
-        "qubes-core-qrexec-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
     ]
     for rpm in rpms:
         assert f"{rpm} has already a valid signature. Skipping." in result
@@ -858,30 +858,30 @@ def test_component_host_fc37_unpublish(artifacts_dir):
         ).decode()
 
         rpms = {
-            "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
         }
-        srpm = "qubes-core-qrexec-4.2.4-1.fc37.src.rpm"
+        srpm = "qubes-core-qrexec-4.2.18-1.fc37.src.rpm"
 
         rpms_dom0 = {
-            "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-            "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+            "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
         }
-        srpm_dom0 = "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm"
+        srpm_dom0 = "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm"
 
         with open(
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec.spec.publish.yml"
         ) as f:
             info = yaml.safe_load(f.read())
 
         with open(
             artifacts_dir
-            / "components/core-qrexec/4.2.4-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
+            / "components/core-qrexec/4.2.18-1/host-fc37/publish/rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
         ) as f:
             info_dom0 = yaml.safe_load(f.read())
 
@@ -903,16 +903,16 @@ def test_component_host_fc37_unpublish(artifacts_dir):
 
     # Check that packages are in the published repository
     rpms = [
-        "qubes-core-qrexec-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debugsource-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-devel-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.src.rpm",
-        "qubes-core-qrexec-dom0-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debugsource-4.2.4-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.2.18-1.fc37.x86_64.rpm",
     ]
     for repository in ["unstable", "current-testing", "current"]:
         repository_dir = (
@@ -1456,44 +1456,44 @@ def test_increment_component_build(artifacts_dir):
         )
 
     rpms = {
-        "qubes-core-qrexec-4.2.4-1.42.fc37.x86_64.rpm",
-        "qubes-core-qrexec-debugsource-4.2.4-1.42.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-4.2.4-1.42.fc37.x86_64.rpm",
-        "qubes-core-qrexec-libs-debuginfo-4.2.4-1.42.fc37.x86_64.rpm",
-        "qubes-core-qrexec-devel-4.2.4-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-4.2.18-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-debugsource-4.2.18-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-4.2.18-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-libs-debuginfo-4.2.18-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-devel-4.2.18-1.42.fc37.x86_64.rpm",
     }
-    srpm = "qubes-core-qrexec-4.2.4-1.42.fc37.src.rpm"
+    srpm = "qubes-core-qrexec-4.2.18-1.42.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.4" / rpm).exists()
+        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
 
     rpms = {
-        "qubes-core-qrexec-dom0-4.2.4-1.42.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debuginfo-4.2.4-1.42.fc37.x86_64.rpm",
-        "qubes-core-qrexec-dom0-debugsource-4.2.4-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-4.2.18-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debuginfo-4.2.18-1.42.fc37.x86_64.rpm",
+        "qubes-core-qrexec-dom0-debugsource-4.2.18-1.42.fc37.x86_64.rpm",
     }
-    srpm = "qubes-core-qrexec-dom0-4.2.4-1.42.fc37.src.rpm"
+    srpm = "qubes-core-qrexec-dom0-4.2.18-1.42.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.4" / rpm).exists()
+        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
 
     deb_files = [
-        "libqrexec-utils-dev_4.2.4-1+deb12u1+devel42_amd64.deb",
-        "libqrexec-utils2-dbgsym_4.2.4-1+deb12u1+devel42_amd64.deb",
-        "libqrexec-utils2_4.2.4-1+deb12u1+devel42_amd64.deb",
-        "python3-qrexec_4.2.4-1+deb12u1+devel42_amd64.deb",
-        "qubes-core-qrexec-dbgsym_4.2.4-1+deb12u1+devel42_amd64.deb",
-        "qubes-core-qrexec_4.2.4-1+deb12u1+devel42.debian.tar.xz",
-        "qubes-core-qrexec_4.2.4-1+deb12u1+devel42.dsc",
-        "qubes-core-qrexec_4.2.4-1+deb12u1+devel42_amd64.buildinfo",
-        "qubes-core-qrexec_4.2.4-1+deb12u1+devel42_amd64.changes",
-        "qubes-core-qrexec_4.2.4-1+deb12u1+devel42_amd64.deb",
-        "qubes-core-qrexec_4.2.4.orig.tar.gz",
+        "libqrexec-utils-dev_4.2.18-1+deb12u1+devel42_amd64.deb",
+        "libqrexec-utils2-dbgsym_4.2.18-1+deb12u1+devel42_amd64.deb",
+        "libqrexec-utils2_4.2.18-1+deb12u1+devel42_amd64.deb",
+        "python3-qrexec_4.2.18-1+deb12u1+devel42_amd64.deb",
+        "qubes-core-qrexec-dbgsym_4.2.18-1+deb12u1+devel42_amd64.deb",
+        "qubes-core-qrexec_4.2.18-1+deb12u1+devel42.debian.tar.xz",
+        "qubes-core-qrexec_4.2.18-1+deb12u1+devel42.dsc",
+        "qubes-core-qrexec_4.2.18-1+deb12u1+devel42_amd64.buildinfo",
+        "qubes-core-qrexec_4.2.18-1+deb12u1+devel42_amd64.changes",
+        "qubes-core-qrexec_4.2.18-1+deb12u1+devel42_amd64.deb",
+        "qubes-core-qrexec_4.2.18.orig.tar.gz",
     ]
 
     for file in deb_files:
         assert (
-            artifacts_dir / "repository/vm-bookworm/core-qrexec_4.2.4" / file
+            artifacts_dir / "repository/vm-bookworm/core-qrexec_4.2.18" / file
         ).exists()
 
 


### PR DESCRIPTION
sqv 1.2.0 supports crypto policy, see:
https://gitlab.com/sequoia-pgp/sequoia-sqv/-/issues/4
Configure it to accept sha1 for key self-signature, but reject for the
actual file signature.

QubesOS/qubes-issues#9012