### PR TITLE
Update Gentoo example config

### DIFF
--- a/example-configs/gentoo.yml
+++ b/example-configs/gentoo.yml
@@ -26,7 +26,7 @@ templates:
 components:
   - builder-gentoo:
       packages: False
-      url: https://github.com/fepitre/qubes-builder-gentoo
+      url: https://github.com/QubesOS/qubes-builder-gentoo
       maintainers:
         # fepitre's @qubes-os.org
         - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2


### PR DESCRIPTION
fepitre's version isn't compatible with v2