### PR TITLE
Add missing components to example ubuntu config

### DIFF
--- a/dockerfiles/debian.Dockerfile
+++ b/dockerfiles/debian.Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 # Install dependencies for Qubes Builder
 RUN apt-get update && \
     apt-get install -y sudo curl debootstrap devscripts dpkg-dev git wget python3-debian e2fsprogs pbuilder tree \
-        reprepro psutils fdisk udev rpm \
+        reprepro psutils fdisk udev rpm python3-yaml \
     && apt-get clean all
 
 # Create build user

--- a/example-configs/ubuntu.yml
+++ b/example-configs/ubuntu.yml
@@ -40,6 +40,9 @@ components:
   - app-linux-usb-proxy
   - app-linux-pdf-converter
   - app-linux-img-converter
+  - mgmt-salt
+  - fwupd
+  - repo-templates
   - meta-packages
 
 executor:


### PR DESCRIPTION
qubes-vm-recommended depends on few more things in Qubes 4.2.

Fixes QubesOS/qubes-issues#9270