### PR TITLE
Improve dependency handling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -428,7 +428,7 @@ local-vm-bookworm:
 # Templates
 #
 
-qubes-template-fedora-38-xfce:
+qubes-template-fedora-40-xfce:
   extends: .template_qubes_job
 
 qubes-template-debian-12:

--- a/qubesbuilder/plugins/build/__init__.py
+++ b/qubesbuilder/plugins/build/__init__.py
@@ -20,11 +20,8 @@
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
-from qubesbuilder.log import get_logger
 from qubesbuilder.pluginmanager import PluginManager
 from qubesbuilder.plugins import DistributionComponentPlugin, PluginError
-
-log = get_logger("build")
 
 
 class BuildError(PluginError):
@@ -41,6 +38,8 @@ class BuildPlugin(DistributionComponentPlugin):
     Entry points:
         - build
     """
+
+    name = "build"
 
     def __init__(
         self,
@@ -59,7 +58,7 @@ class BuildPlugin(DistributionComponentPlugin):
             return
 
         if not self.get_parameters(stage).get("build", []):
-            log.info(f"{self.component}:{self.dist}: Nothing to be done.")
+            self.log.info(f"{self.component}:{self.dist}: Nothing to be done.")
             return
 
         # Ensure all build targets artifacts exist from previous required stage

--- a/qubesbuilder/plugins/build_deb/scripts/patch-changes
+++ b/qubesbuilder/plugins/build_deb/scripts/patch-changes
@@ -20,7 +20,6 @@
 
 import argparse
 import hashlib
-import sys
 from typing import List, Dict, Type
 
 from debian.deb822 import Deb822, Changes, Dsc

--- a/qubesbuilder/plugins/chroot/__init__.py
+++ b/qubesbuilder/plugins/chroot/__init__.py
@@ -20,13 +20,10 @@
 from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import (
     DistributionPlugin,
     PluginError,
 )
-
-log = get_logger("chroot")
 
 
 class ChrootError(PluginError):
@@ -37,6 +34,8 @@ class ChrootPlugin(DistributionPlugin):
     """
     ChrootPlugin manages generic chroot creation
     """
+
+    name = "chroot"
 
     def __init__(
         self,

--- a/qubesbuilder/plugins/chroot_archlinux/__init__.py
+++ b/qubesbuilder/plugins/chroot_archlinux/__init__.py
@@ -20,12 +20,9 @@
 from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import ExecutorError
-from qubesbuilder.log import get_logger
 from qubesbuilder.pluginmanager import PluginManager
 from qubesbuilder.plugins import ArchlinuxDistributionPlugin
 from qubesbuilder.plugins.chroot import ChrootError, ChrootPlugin
-
-log = get_logger("chroot_archlinux")
 
 
 def get_pacman_cmd(
@@ -96,6 +93,7 @@ class ArchlinuxChrootPlugin(ArchlinuxDistributionPlugin, ChrootPlugin):
         - chroot - Create Archlinux cache chroot.
     """
 
+    name = "chroot_archlinux"
     stages = ["init-cache"]
 
     def __init__(
@@ -124,18 +122,9 @@ class ArchlinuxChrootPlugin(ArchlinuxDistributionPlugin, ChrootPlugin):
         chroot_archive = f"{chroot_name}.tar.gz"
         (cache_chroot_dir / chroot_archive).unlink(missing_ok=True)
 
-        copy_in = [
-            (
-                self.manager.entities["chroot_archlinux"].directory,
-                executor.get_plugins_dir(),
-            ),
-        ] + [
-            (
-                self.manager.entities[dependency].directory,
-                executor.get_plugins_dir(),
-            )
-            for dependency in self.dependencies
-        ]
+        copy_in = self.default_copy_in(
+            executor.get_plugins_dir(), executor.get_sources_dir()
+        )
         self.environment.update(
             {
                 "DIST": self.dist.name,

--- a/qubesbuilder/plugins/chroot_archlinux/scripts/generate-pacman
+++ b/qubesbuilder/plugins/chroot_archlinux/scripts/generate-pacman
@@ -2,6 +2,7 @@
 
 import argparse
 import pathlib
+
 from jinja2 import Environment, BaseLoader
 
 DEFAULT_SERVERS = [

--- a/qubesbuilder/plugins/chroot_deb/__init__.py
+++ b/qubesbuilder/plugins/chroot_deb/__init__.py
@@ -23,11 +23,8 @@ from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import ExecutorError
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import DEBDistributionPlugin
 from qubesbuilder.plugins.chroot import ChrootPlugin, ChrootError
-
-log = get_logger("chroot_deb")
 
 
 class DEBChrootPlugin(DEBDistributionPlugin, ChrootPlugin):
@@ -38,6 +35,7 @@ class DEBChrootPlugin(DEBDistributionPlugin, ChrootPlugin):
         - chroot - Create pbuilder base.tgz.
     """
 
+    name = "chroot_deb"
     stages = ["init-cache"]
 
     def __init__(
@@ -72,12 +70,9 @@ class DEBChrootPlugin(DEBDistributionPlugin, ChrootPlugin):
         ]
 
         # Create a first cage to generate the base.tgz
-        copy_in = [
-            (
-                self.manager.entities["chroot_deb"].directory,
-                executor.get_plugins_dir(),
-            ),
-        ]
+        copy_in = self.default_copy_in(
+            executor.get_plugins_dir(), executor.get_sources_dir()
+        )
         copy_out = [
             (
                 executor.get_builder_dir() / "pbuilder/base.tgz",
@@ -120,15 +115,13 @@ class DEBChrootPlugin(DEBDistributionPlugin, ChrootPlugin):
             .get("packages", [])
         )
         if additional_packages:
-            copy_in = [
-                (
-                    self.manager.entities["chroot_deb"].directory,
-                    executor.get_plugins_dir(),
-                ),
+            copy_in = self.default_copy_in(
+                executor.get_plugins_dir(), executor.get_sources_dir()
+            ) + [
                 (
                     chroot_dir / "base.tgz",
                     executor.get_builder_dir() / "pbuilder",
-                ),
+                )
             ]
             copy_out = [
                 (

--- a/qubesbuilder/plugins/chroot_rpm/__init__.py
+++ b/qubesbuilder/plugins/chroot_rpm/__init__.py
@@ -23,11 +23,8 @@ from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import ExecutorError
 from qubesbuilder.executors.container import ContainerExecutor
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import RPMDistributionPlugin
 from qubesbuilder.plugins.chroot import ChrootError, ChrootPlugin
-
-log = get_logger("chroot_rpm")
 
 
 class RPMChrootPlugin(RPMDistributionPlugin, ChrootPlugin):
@@ -38,6 +35,7 @@ class RPMChrootPlugin(RPMDistributionPlugin, ChrootPlugin):
         - chroot - Create Mock cache chroot.
     """
 
+    name = "chroot_rpm"
     stages = ["init-cache"]
 
     def __init__(
@@ -95,7 +93,7 @@ class RPMChrootPlugin(RPMDistributionPlugin, ChrootPlugin):
                 f"{self.dist}: Mock isolation set to 'simple', build has full network "
                 f"access. Use 'qubes' executor for network-isolated build."
             )
-            log.warning(msg)
+            self.log.warning(msg)
             mock_cmd.append("--isolation=simple")
         else:
             mock_cmd.append("--isolation=nspawn")
@@ -103,12 +101,9 @@ class RPMChrootPlugin(RPMDistributionPlugin, ChrootPlugin):
             mock_cmd.append("--verbose")
 
         # Create a first cage to generate the mock chroot
-        copy_in = [
-            (
-                self.manager.entities["chroot_rpm"].directory,
-                executor.get_plugins_dir(),
-            ),
-        ]
+        copy_in = self.default_copy_in(
+            executor.get_plugins_dir(), executor.get_sources_dir()
+        )
         copy_out = [
             (
                 executor.get_cache_dir() / f"mock/{mock_chroot_name}",
@@ -138,11 +133,9 @@ class RPMChrootPlugin(RPMDistributionPlugin, ChrootPlugin):
             # Remove dnf_cache
             if (chroot_dir / mock_chroot_name / "dnf_cache").exists():
                 shutil.rmtree(chroot_dir / mock_chroot_name / "dnf_cache")
-            copy_in = [
-                (
-                    self.manager.entities["chroot_rpm"].directory,
-                    executor.get_plugins_dir(),
-                ),
+            copy_in = self.default_copy_in(
+                executor.get_plugins_dir(), executor.get_sources_dir()
+            ) + [
                 (chroot_dir / mock_chroot_name, executor.get_cache_dir() / f"mock"),
             ]
             copy_out = [

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
@@ -26,7 +26,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Any
+from typing import List
 
 
 def verify_git_obj(gpg_client, keyring_dir, repository_dir, obj_type, obj_path):

--- a/qubesbuilder/plugins/installer/scripts/tmplparser
+++ b/qubesbuilder/plugins/installer/scripts/tmplparser
@@ -9,7 +9,6 @@ import tempfile
 import dnf
 import dnf.exceptions
 import dnf.subject
-
 from pylorax.dnfbase import get_dnf_base_object
 from pylorax.ltmpl import LoraxTemplate
 

--- a/qubesbuilder/plugins/publish/__init__.py
+++ b/qubesbuilder/plugins/publish/__init__.py
@@ -24,10 +24,7 @@ from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors.local import LocalExecutor
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import DistributionComponentPlugin, PluginError
-
-log = get_logger("publish")
 
 # Define the minimum age for which packages can be published to 'current'
 COMPONENT_REPOSITORIES = ["current", "current-testing", "security-testing", "unstable"]
@@ -47,6 +44,8 @@ class PublishPlugin(DistributionComponentPlugin):
     Entry points:
         - build
     """
+
+    name = "publish"
 
     def __init__(
         self,
@@ -93,7 +92,9 @@ class PublishPlugin(DistributionComponentPlugin):
                 break
 
         if not publish_date:
-            log.error("Something wrong detected in repositories. Missing timestamp?")
+            self.log.error(
+                "Something wrong detected in repositories. Missing timestamp?"
+            )
             return False
 
         # Check that packages have been published before threshold_date
@@ -122,5 +123,5 @@ class PublishPlugin(DistributionComponentPlugin):
 
         # Check if we have Debian related content defined
         if not self.get_parameters(stage).get("build", []):
-            log.info(f"{self.component}:{self.dist}: Nothing to be done.")
+            self.log.info(f"{self.component}:{self.dist}: Nothing to be done.")
             return

--- a/qubesbuilder/plugins/sign/__init__.py
+++ b/qubesbuilder/plugins/sign/__init__.py
@@ -22,10 +22,7 @@ from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors.local import LocalExecutor
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import DistributionComponentPlugin, PluginError
-
-log = get_logger("sign")
 
 
 class SignError(PluginError):
@@ -42,6 +39,8 @@ class SignPlugin(DistributionComponentPlugin):
     Entry points:
         - build
     """
+
+    name = "sign"
 
     def __init__(
         self,
@@ -64,7 +63,7 @@ class SignPlugin(DistributionComponentPlugin):
 
         # Check if we have Debian related content defined
         if not self.get_parameters(stage).get("build", []):
-            log.info(f"{self.component}:{self.dist}: Nothing to be done.")
+            self.log.info(f"{self.component}:{self.dist}: Nothing to be done.")
             return
 
         if not isinstance(executor, LocalExecutor):

--- a/qubesbuilder/plugins/sign_archlinux/__init__.py
+++ b/qubesbuilder/plugins/sign_archlinux/__init__.py
@@ -25,12 +25,9 @@ from qubesbuilder.component import QubesComponent
 from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import ExecutorError
-from qubesbuilder.log import get_logger
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.plugins import ArchlinuxDistributionPlugin
+from qubesbuilder.plugins import ArchlinuxDistributionPlugin, PluginDependency
 from qubesbuilder.plugins.sign import SignPlugin, SignError
-
-log = get_logger("sign_archlinux")
 
 
 class ArchlinuxSignPlugin(ArchlinuxDistributionPlugin, SignPlugin):
@@ -44,8 +41,9 @@ class ArchlinuxSignPlugin(ArchlinuxDistributionPlugin, SignPlugin):
         - build
     """
 
+    name = "sign_archlinux"
     stages = ["sign"]
-    dependencies = ["sign"]
+    dependencies = [PluginDependency("sign")]
 
     def __init__(
         self,
@@ -75,12 +73,12 @@ class ArchlinuxSignPlugin(ArchlinuxDistributionPlugin, SignPlugin):
             self.dist.distribution, None
         ) or self.config.sign_key.get("archlinux", None)
         if not sign_key:
-            log.info(f"{self.component}:{self.dist}: No signing key found.")
+            self.log.info(f"{self.component}:{self.dist}: No signing key found.")
             return
 
         # Check if we have a gpg client provided
         if not self.config.gpg_client:
-            log.info(f"{self.component}: Please specify GPG client to use!")
+            self.log.info(f"{self.component}: Please specify GPG client to use!")
             return
 
         # Build artifacts (source included)
@@ -120,7 +118,9 @@ class ArchlinuxSignPlugin(ArchlinuxDistributionPlugin, SignPlugin):
             )
 
             if not build_info.get("packages", None):
-                log.info(f"{self.component}:{self.dist}:{directory}: Nothing to sign.")
+                self.log.info(
+                    f"{self.component}:{self.dist}:{directory}: Nothing to sign."
+                )
                 continue
 
             packages_list = [
@@ -129,7 +129,7 @@ class ArchlinuxSignPlugin(ArchlinuxDistributionPlugin, SignPlugin):
 
             try:
                 for pkg in packages_list:
-                    log.info(
+                    self.log.info(
                         f"{self.component}:{self.dist}:{directory}: Signing '{pkg.name}'."
                     )
                     cmd = [

--- a/qubesbuilder/plugins/source/__init__.py
+++ b/qubesbuilder/plugins/source/__init__.py
@@ -21,10 +21,11 @@ from qubesbuilder.component import QubesComponent
 from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.log import get_logger
-from qubesbuilder.plugins import DistributionComponentPlugin, PluginError
-
-log = get_logger("source")
+from qubesbuilder.plugins import (
+    DistributionComponentPlugin,
+    PluginError,
+    PluginDependency,
+)
 
 
 class SourceError(PluginError):
@@ -42,7 +43,8 @@ class SourcePlugin(DistributionComponentPlugin):
         - source
     """
 
-    dependencies = ["fetch"]
+    name = "source"
+    dependencies = [PluginDependency("fetch")]
 
     def __init__(
         self,

--- a/qubesbuilder/plugins/upload/__init__.py
+++ b/qubesbuilder/plugins/upload/__init__.py
@@ -21,11 +21,8 @@ from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors.local import LocalExecutor, ExecutorError
 from qubesbuilder.pluginmanager import PluginManager
-from qubesbuilder.log import get_logger
 from qubesbuilder.plugins import DistributionPlugin, PluginError
 from qubesbuilder.plugins.publish_deb import DEBPublishPlugin
-
-log = get_logger("upload")
 
 
 class UploadError(PluginError):
@@ -40,6 +37,7 @@ class UploadPlugin(DistributionPlugin):
         - upload - Upload published repository for given distribution to remote mirror.
     """
 
+    name = "upload"
     stages = ["upload"]
 
     def __init__(
@@ -73,7 +71,7 @@ class UploadPlugin(DistributionPlugin):
             self.dist.type, None
         )
         if not remote_path:
-            log.info(f"{self.dist}: No remote location defined. Skipping.")
+            self.log.info(f"{self.dist}: No remote location defined. Skipping.")
             return
 
         repository_publish = repository_publish or self.config.repository_publish.get(


### PR DESCRIPTION
The goal of this work is to improve how dependencies are handled in plugins. Previously, we only supported specifying dependencies as string names, indicating which other plugins were needed to run properly. However, in some cases, we also need to specify components such as `builder-*` or `qubes-release`. 

With this PR, we introduce a basic and simple object to represent `plugin` or `component` dependencies. This ensures that required dependencies are available before execution. Additionally, it prevents code duplication and makes it easier to automatically copy dependencies.