### PR TITLE
ci: update fedora jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -323,9 +323,6 @@ cache-vm-fc39:
 cache-vm-fc40:
   extends: .init_cache_job
 
-cache-vm-centos-stream8:
-  extends: .init_cache_job
-
 cache-vm-bookworm:
   extends: .init_cache_job
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -317,10 +317,10 @@ cache-host-fc37:
     - !reference [.init_cache_job, script ]
     - tests/scripts/check-chroot-content.sh artifacts "${CI_JOB_NAME#cache-}" /usr/bin/gcc
 
-cache-vm-fc37:
+cache-vm-fc39:
   extends: .init_cache_job
 
-cache-vm-fc38:
+cache-vm-fc40:
   extends: .init_cache_job
 
 cache-vm-centos-stream8:
@@ -348,10 +348,10 @@ podman-host-fc37:
   needs:
     - cache-host-fc37
 
-podman-vm-fc38:
+podman-vm-fc40:
   extends: .component_podman_job
   needs:
-    - cache-vm-fc38
+    - cache-vm-fc40
 
 #podman-vm-bookworm:
 #  extends: .component_podman_job
@@ -363,10 +363,10 @@ docker-host-fc37:
   needs:
     - cache-host-fc37
 
-docker-vm-fc38:
+docker-vm-fc40:
   extends: .component_docker_job
   needs:
-    - cache-vm-fc38
+    - cache-vm-fc40
 
 docker-vm-bookworm:
   extends: .component_docker_job
@@ -400,10 +400,10 @@ qubes-host-fc37:
   needs:
     - cache-host-fc37
 
-qubes-vm-fc38:
+qubes-vm-fc40:
   extends: .component_qubes_job
   needs:
-    - cache-vm-fc38
+    - cache-vm-fc40
 
 qubes-vm-bookworm:
   extends: .component_qubes_job
@@ -417,10 +417,10 @@ local-host-fc37:
   needs:
     - cache-host-fc37
 
-local-vm-fc38:
+local-vm-fc40:
   extends: .component_local_job
   needs:
-    - cache-vm-fc38
+    - cache-vm-fc40
 
 local-vm-bookworm:
   extends: .component_local_job

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -47,6 +47,7 @@ distributions:
   - vm-bullseye
   - vm-bookworm
   - vm-trixie
+  - vm-fc39
   - vm-fc40
   - vm-archlinux
   - vm-focal
@@ -78,7 +79,7 @@ components:
   - core-qrexec:
       branch: v4.2.18
   - desktop-linux-xfce4-xfwm4:
-      branch: v4.16.1-3
+      branch: v4.16.1-4
   - app-linux-split-gpg:
       branch: v2.0.67-builderv2-tests
       url: https://github.com/fepitre/qubes-app-linux-split-gpg


### PR DESCRIPTION
vm-fc37 and vm-fc38 is EOL, move to fc39+fc40