### PR TITLE
Installer init cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -305,6 +305,11 @@ pytest-cli-template-debian:
   script:
     - pytest-3 $PYTEST_ARGS tests/test_cli.py -k test_template_debian
 
+pytest-cli-installer-cache:
+  extends: .pytest
+  script:
+    - pytest-3 $PYTEST_ARGS tests/test_cli.py -k test_installer_init_cache
+
 #
 # Components
 #

--- a/README.md
+++ b/README.md
@@ -759,6 +759,7 @@ Options available in `builder.yml`:
 - `cache: Dict` --- List of distributions cache options.
   - `<distribution_name>: Dict` --- Distribution name provided as in `distributions`.
     - `packages: List[str]` --- List of packages to download and to put in cache. These packages won't be installed into the base chroot.
+  - `<template_repository>: List[str]` --- List of template names to download and put in cache. Template repository can be either `templates-itl` or `templates-community`.` 
 
 - `automatic-upload-on-publish: bool` --- Automatic upload on publish/unpublish.
 

--- a/dockerfiles/fedora-mock.Dockerfile
+++ b/dockerfiles/fedora-mock.Dockerfile
@@ -6,10 +6,39 @@ ADD cache.tar.gz /
 
 # Install dependencies for Qubes Builder
 RUN dnf -y update && \
-    dnf install -y dnf-plugins-core createrepo_c debootstrap devscripts dpkg-dev git mock pbuilder \
-        which perl-Digest-MD5 perl-Digest-SHA python3-pyyaml e2fsprogs \
-        python3-sh rpm-build rpmdevtools wget python3-debian reprepro systemd-udev \
-        tree python3-jinja2-cli pacman m4 asciidoc rsync psmisc zstd archlinux-keyring debian-keyring arch-install-scripts \
+    dnf install -y \
+        arch-install-scripts \
+        archlinux-keyring \
+        asciidoc \
+        createrepo_c \
+        debian-keyring \
+        debootstrap \
+        devscripts \
+        dnf-plugins-core \
+        dpkg-dev \
+        e2fsprogs \
+        git \
+        m4 \
+        mock \
+        pacman \
+        pbuilder \
+        perl-Digest-MD5 \
+        perl-Digest-SHA \
+        psmisc \
+        python3-debian \
+        python3-jinja2-cli \
+        python3-pyyaml \
+        python3-sh \
+        pykickstart \
+        reprepro \
+        rpm-build \
+        rpmdevtools \
+        rsync  \
+        systemd-udev \
+        tree \
+        wget \
+        which \
+        zstd \
     && dnf clean all
 
 # Install devtools for Archlinux

--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -3,10 +3,39 @@ MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 
 # Install dependencies for Qubes Builder
 RUN dnf -y update && \
-    dnf install -y dnf-plugins-core createrepo_c debootstrap devscripts dpkg-dev git mock pbuilder \
-        which perl-Digest-MD5 perl-Digest-SHA python3-pyyaml e2fsprogs \
-        python3-sh rpm-build rpmdevtools wget python3-debian reprepro systemd-udev \
-        tree python3-jinja2-cli pacman m4 asciidoc rsync psmisc zstd archlinux-keyring debian-keyring arch-install-scripts \
+    dnf install -y \
+        arch-install-scripts \
+        archlinux-keyring \
+        asciidoc \
+        createrepo_c \
+        debian-keyring \
+        debootstrap \
+        devscripts \
+        dnf-plugins-core \
+        dpkg-dev \
+        e2fsprogs \
+        git \
+        m4 \
+        mock \
+        pacman \
+        pbuilder \
+        perl-Digest-MD5 \
+        perl-Digest-SHA \
+        psmisc \
+        python3-debian \
+        python3-jinja2-cli \
+        python3-pyyaml \
+        python3-sh \
+        pykickstart \
+        reprepro \
+        rpm-build \
+        rpmdevtools \
+        rsync  \
+        systemd-udev \
+        tree \
+        wget \
+        which \
+        zstd \
     && dnf clean all
 
 # Install devtools for Archlinux

--- a/example-configs/builder-devel.yml
+++ b/example-configs/builder-devel.yml
@@ -283,3 +283,18 @@ mirrors:
   # in case where one of them fails.
   debian:
     - http://ftp.fr.debian.org/debian/
+
+cache:
+  vm-fc41:
+    packages:
+      - cargo
+      - rust-cc-devel
+      - rust-libc-devel
+      - cargo-rpm-macros
+      - rpm-devel
+  templates-itl:
+    - fedora-39-xfce
+    - debian-12-xfce
+  templates-community:
+    - whonix-gateway-17
+    - whonix-workstation-17

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -535,3 +535,11 @@ class Config:
         else:
             config_path = Path(config_path_str).resolve()
         return config_path
+
+    def parse_qubes_release(self):
+        parsed_release = QUBES_RELEASE_RE.match(
+            self.qubes_release
+        ) or QUBES_RELEASE_RE.match(QUBES_RELEASE_DEFAULT)
+        if not parsed_release:
+            raise ConfigError(f"Cannot parse Qubes OS release: '{self.qubes_release}'")
+        return parsed_release

--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -28,6 +28,7 @@ INSTALLER_KICKSTART ?= $(SOURCES_DIR)/qubes-release/conf/qubes-kickstart.cfg
 CREATEREPO := $(shell which createrepo_c createrepo 2>/dev/null |head -1)
 ISO_VERSION ?= $(shell date +%Y%m%d)
 COMPS_FILE ?= $(SOURCES_DIR)/qubes-release/comps/comps-dom0.xml
+QUBES_VERSION ?= $(shell cat $(SOURCES_DIR)/qubes-release/version)
 
 ifneq (,$(ISO_FLAVOR))
 ISO_NAME := Qubes-$(ISO_VERSION)-$(ISO_FLAVOR)-x86_64
@@ -44,6 +45,7 @@ DNF_ROOT := $(BUILDER_DIR)/dnfroot
 DNF_REPO := $(DNF_ROOT)/etc/yum.repos.d/installer.repo
 DNF_PACKAGES := $(DNF_ROOT)/tmp/packages.list
 DNF_OPTS := -y --releasever=$(DIST_VER) --installroot=$(DNF_ROOT) --config=$(DNF_ROOT)/etc/dnf/dnf.conf
+DNF_OPTS_TEMPLATES := $(DNF_OPTS) --repofrompath builder-local,$(BUILDER_DIR)/repository
 
 LORAX := /usr/sbin/lorax
 LORAX_PACKAGES := $(DNF_ROOT)/tmp/lorax_packages.list
@@ -53,11 +55,25 @@ LORAX_OPTS += --workdir $(INSTALLER_DIR)/work/work/x86_64 --logfile $(INSTALLER_
 LORAX_OPTS += --repo $(DNF_REPO) --skip-branding --disablerepo=fedora --disablerepo=fedora-updates --disablerepo=updates --disablerepo='qubes-*'
 
 ifeq ($(ISO_USE_KERNEL_LATEST),1)
-LORAX_OPTS += --installpkgs kernel-latest --excludepkgs kernel
+    LORAX_OPTS += --installpkgs kernel-latest --excludepkgs kernel
 endif
 
 ifeq ($(ISO_IS_FINAL),1)
-	LORAX_OPTS += --isfinal
+    LORAX_OPTS += --isfinal
+endif
+
+ifeq ($(USE_QUBES_REPO_TEMPLATES_ITL),1)
+    DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-itl
+    ifeq ($(USE_QUBES_REPO_TESTING),1)
+        DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-itl-testing
+    endif
+endif
+
+ifeq ($(USE_QUBES_REPO_TEMPLATES_COMMUNITY),1)
+    DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-community
+    ifeq ($(USE_QUBES_REPO_TESTING),1)
+        DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-community-testing
+    endif
 endif
 
 #
@@ -126,6 +142,19 @@ iso-packages-lorax:
 	umask 022; $(DNF) $(DNF_OPTS) --downloaddir=$(INSTALLER_DIR)/yum/installer/rpm --downloadonly install $(shell cat $(LORAX_PACKAGES))
 	pushd $(INSTALLER_DIR)/yum/installer && $(CREATEREPO) -q -g $(TMP_DIR)/comps.xml --update .
 
+iso-templates-cache: iso-prepare
+	$(DNF) $(DNF_OPTS) clean all
+	mkdir -p $(DNF_ROOT)/etc/yum.repos.d/ $(DNF_ROOT)/etc/qubes/repo-templates/keys/
+	cp -r $(SOURCES_DIR)/repo-templates/repos/RPM-GPG-KEY-* $(DNF_ROOT)/etc/qubes/repo-templates/keys/
+	cp $(SOURCES_DIR)/repo-templates/repos/qubes-templates.repo $(DNF_ROOT)/etc/yum.repos.d/
+
+	# Adapt repo file for new dnfroot
+	sed -i -e 's/$$releasever/$(QUBES_VERSION)/g' $(DNF_ROOT)/etc/yum.repos.d/qubes-templates.repo
+	sed -i 's|gpgkey *= *file://\(.*\)|gpgkey=file://$(DNF_ROOT)\1|g' $(DNF_ROOT)/etc/yum.repos.d/qubes-templates.repo
+
+	rpmkeys --root=$(DNF_ROOT) --import $$(sed -n '/gpgkey *= *file:/{s,.*file://,,;p}' $(DNF_ROOT)/etc/yum.repos.d/*.repo)
+	umask 022; $(DNF) $(DNF_OPTS_TEMPLATES) --downloaddir=$(INSTALLER_DIR)/yum/installer/rpm --downloaddir=$(BUILDER_DIR)/repository/templates download $(TEMPLATE_PACKAGES)
+
 #
 # CAGE -> MOCK
 #
@@ -153,5 +182,3 @@ iso-installer-mkisofs:
 		.=$(BASE_DIR)/os \
 		boot/grub2/i386-pc=/usr/lib/grub/i386-pc
 	/usr/bin/implantisomd5 $(BASE_DIR)/iso/$(ISO_NAME).iso
-
-

--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -45,7 +45,7 @@ DNF_ROOT := $(BUILDER_DIR)/dnfroot
 DNF_REPO := $(DNF_ROOT)/etc/yum.repos.d/installer.repo
 DNF_PACKAGES := $(DNF_ROOT)/tmp/packages.list
 DNF_OPTS := -y --releasever=$(DIST_VER) --installroot=$(DNF_ROOT) --config=$(DNF_ROOT)/etc/dnf/dnf.conf
-DNF_OPTS_TEMPLATES := $(DNF_OPTS) --repofrompath builder-local,$(BUILDER_DIR)/repository
+DNF_OPTS_TEMPLATES := $(DNF_OPTS) --disablerepo=* --repofrompath builder-local,$(BUILDER_DIR)/repository
 
 LORAX := /usr/sbin/lorax
 LORAX_PACKAGES := $(DNF_ROOT)/tmp/lorax_packages.list
@@ -63,22 +63,23 @@ ifeq ($(ISO_IS_FINAL),1)
 endif
 
 ifeq ($(USE_QUBES_REPO_TEMPLATES_ITL),1)
-    DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-itl
+    DNF_OPTS_TEMPLATES += --enablerepo=qubes*templates-itl
     ifeq ($(USE_QUBES_REPO_TESTING),1)
-        DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-itl-testing
+        DNF_OPTS_TEMPLATES += --enablerepo=qubes*templates-itl-testing
     endif
 endif
 
 ifeq ($(USE_QUBES_REPO_TEMPLATES_COMMUNITY),1)
-    DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-community
+    DNF_OPTS_TEMPLATES += --enablerepo=qubes*templates-community
     ifeq ($(USE_QUBES_REPO_TESTING),1)
-        DNF_OPTS_TEMPLATES += --enablerepo=qubes-templates-community-testing
+        DNF_OPTS_TEMPLATES += --enablerepo=qubes*templates-community-testing
     endif
 endif
 
 #
-# CAGE -> MOCK
+# CAGE -> MOCK | CAGE
 #
+
 iso-prepare:
 	#
 	# Prepare repositories
@@ -119,9 +120,17 @@ iso-prepare:
 	mkdir -p $(DNF_ROOT)/etc/pki/rpm-gpg
 	cp $(SOURCES_DIR)/qubes-release/RPM-GPG-KEY-fedora-$(DIST_VER)-primary $(DNF_ROOT)/etc/pki/rpm-gpg
 
+#
+# CAGE | CAGE -> MOCK
+#
+
 iso-parse-kickstart:
 	mkdir -p $(DNF_ROOT)/etc/yum.repos.d $(DNF_ROOT)/tmp
-	$(INSTALLER_DIR)/scripts/ksparser --ks $(INSTALLER_KICKSTART) --extract-repo-conf-to $(DNF_REPO) --extract-packages-to $(DNF_PACKAGES)
+	$(INSTALLER_DIR)/scripts/ksparser --extract-repo-conf-to $(DNF_REPO) --extract-packages-to $(DNF_PACKAGES) $(INSTALLER_KICKSTART)
+
+#
+# CAGE -> MOCK
+#
 
 iso-parse-tmpl:
 	$(INSTALLER_DIR)/scripts/tmplparser --repo $(DNF_REPO) --extract-packages-to $(LORAX_PACKAGES)
@@ -142,22 +151,23 @@ iso-packages-lorax:
 	umask 022; $(DNF) $(DNF_OPTS) --downloaddir=$(INSTALLER_DIR)/yum/installer/rpm --downloadonly install $(shell cat $(LORAX_PACKAGES))
 	pushd $(INSTALLER_DIR)/yum/installer && $(CREATEREPO) -q -g $(TMP_DIR)/comps.xml --update .
 
-iso-templates-cache: iso-prepare
-	$(DNF) $(DNF_OPTS) clean all
-	mkdir -p $(DNF_ROOT)/etc/yum.repos.d/ $(DNF_ROOT)/etc/qubes/repo-templates/keys/
-	cp -r $(SOURCES_DIR)/repo-templates/repos/RPM-GPG-KEY-* $(DNF_ROOT)/etc/qubes/repo-templates/keys/
-	cp $(SOURCES_DIR)/repo-templates/repos/qubes-templates.repo $(DNF_ROOT)/etc/yum.repos.d/
+iso-templates-cache: iso-prepare iso-parse-kickstart
+	#mkdir -p $(DNF_ROOT)/etc/yum.repos.d/ $(DNF_ROOT)/etc/qubes/repo-templates/keys/
+	#cp -r $(SOURCES_DIR)/repo-templates/repos/RPM-GPG-KEY-* $(DNF_ROOT)/etc/qubes/repo-templates/keys/
+	#cp $(SOURCES_DIR)/repo-templates/repos/qubes-templates.repo $(DNF_ROOT)/etc/yum.repos.d/
 
 	# Adapt repo file for new dnfroot
-	sed -i -e 's/$$releasever/$(QUBES_VERSION)/g' $(DNF_ROOT)/etc/yum.repos.d/qubes-templates.repo
-	sed -i 's|gpgkey *= *file://\(.*\)|gpgkey=file://$(DNF_ROOT)\1|g' $(DNF_ROOT)/etc/yum.repos.d/qubes-templates.repo
+	#sed -i -e 's/$$releasever/$(QUBES_VERSION)/g' $(DNF_ROOT)/etc/yum.repos.d/qubes-templates.repo
+	#sed -i 's|gpgkey *= *file://\(.*\)|gpgkey=file://$(DNF_ROOT)\1|g' $(DNF_ROOT)/etc/yum.repos.d/qubes-templates.repo
 
+	$(DNF) $(DNF_OPTS) clean all
 	rpmkeys --root=$(DNF_ROOT) --import $$(sed -n '/gpgkey *= *file:/{s,.*file://,,;p}' $(DNF_ROOT)/etc/yum.repos.d/*.repo)
 	umask 022; $(DNF) $(DNF_OPTS_TEMPLATES) --downloaddir=$(INSTALLER_DIR)/yum/installer/rpm --downloaddir=$(BUILDER_DIR)/repository/templates download $(TEMPLATE_PACKAGES)
 
 #
 # CAGE -> MOCK
 #
+
 iso-installer-lorax:
 	$(LORAX) $(LORAX_OPTS) $(BASE_DIR)/os
 

--- a/qubesbuilder/plugins/installer/__init__.py
+++ b/qubesbuilder/plugins/installer/__init__.py
@@ -226,16 +226,18 @@ class InstallerPlugin(DistributionPlugin):
             template_info = self.get_artifacts_info(
                 "build", template.name, self.get_templates_dir()
             )
-            if not template_info:
+            if not template_info or len(template_info.get("rpms", [])) != 1:
                 self.log.warning(
-                    f"{self.dist}: Template {template.name} not built locally"
+                    f"{self.dist}: Template {template.name} is not built locally."
                 )
                 continue
-            assert len(template_info["rpms"]) == 1
-            rpm = template_info["rpms"][0]
-            yield (
-                self.get_templates_dir() / "rpm" / rpm
-            ), executor.get_repository_dir()
+            rpm_path = self.get_templates_dir() / "rpm" / template_info["rpms"][0]
+            if not rpm_path.exists():
+                self.log.warning(
+                    f"{self.dist}:{template.name}: Cannot find {rpm_path}."
+                )
+                continue
+            yield rpm_path, executor.get_repository_dir()
 
     def run(self, stage: str, iso_timestamp: str = None):
         if stage not in self.stages:

--- a/qubesbuilder/plugins/installer/scripts/ksparser
+++ b/qubesbuilder/plugins/installer/scripts/ksparser
@@ -3,8 +3,9 @@
 import argparse
 
 from jinja2 import Environment
+from pykickstart.commands.repo import F27_RepoData, F33_Repo, F33
+from pykickstart.handlers.f33 import F33Handler
 from pykickstart.parser import *
-from pykickstart.version import makeVersion
 
 REPO_TEMPLATE = """
 [{{ks_repo.name}}]
@@ -28,42 +29,66 @@ enablegroups=0
 """
 
 
+class QubesOS_Repo(F33_Repo):
+
+    def _getParser(self):
+        op = F33_Repo._getParser(self)
+        op.add_argument(
+            "--gpgkey",
+            action="store",
+            version=F33,
+            help="This will be used to verify packages.",
+        )
+        return op
+
+
+class QubesOS_RepoData(F27_RepoData):
+    def __init__(self, *args, **kwargs):
+        F27_RepoData.__init__(self, *args, **kwargs)
+        self.gpgkey = kwargs.get("gpgkey", "")
+
+    def _getArgsAsStr(self):
+        retval = F27_RepoData._getArgsAsStr(self)
+        if self.gpgkey:
+            retval += ' --gpgkey="%s"' % self.gpgkey
+
+        return retval
+
+
+commandMap = F33Handler.commandMap
+commandMap["repo"] = QubesOS_Repo
+
+dataMap = F33Handler.dataMap
+dataMap["RepoData"] = QubesOS_RepoData
+
+
 def get_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--ks",
-        metavar='PATH',
-        required=True
-    )
-    parser.add_argument(
-        "--extract-repo-conf-to",
-        metavar='PATH',
-        required=False
-    )
-    parser.add_argument(
-        "--extract-packages-to",
-        metavar='PATH',
-        required=False
-    )
+    parser.add_argument("ks", metavar="PATH")
+    parser.add_argument("-r", "--extract-repo-conf-to", metavar="PATH", required=False)
+    parser.add_argument("-p", "--extract-packages-to", metavar="PATH", required=False)
     return parser.parse_args()
 
 
 def main():
     args = get_args()
     if args.ks:
-        handler = makeVersion()
+        handler = F33Handler(mapping=commandMap, dataMapping=dataMap)
         ksparser = KickstartParser(handler)
         ksparser.readKickstart(args.ks)
 
-        repo_content = ''
+        repo_content = ""
 
         if args.extract_repo_conf_to:
             for ks_repo in ksparser.handler.repo.repoList:
-                repo_content += Environment().from_string(REPO_TEMPLATE).render(
-                    ks_repo=ks_repo.__dict__)
+                repo_content += (
+                    Environment()
+                    .from_string(REPO_TEMPLATE)
+                    .render(ks_repo=ks_repo.__dict__)
+                )
 
             try:
-                with open(args.extract_repo_conf_to, 'w') as repo_fd:
+                with open(args.extract_repo_conf_to, "w") as repo_fd:
                     repo_fd.write(repo_content)
             except EnvironmentError:
                 print("Cannot write repo file to %s" % args.extract_repo_conf_to)
@@ -72,24 +97,24 @@ def main():
         if args.extract_packages_to:
             packages = []
             for group in ksparser.handler.packages.groupList:
-                packages.append('@%s' % group.name)
+                packages.append("@%s" % group.name)
 
             for pkg in ksparser.handler.packages.packageList:
-                packages.append('%s' % pkg)
+                packages.append("%s" % pkg)
 
             # for group in ksparser.handler.packages.excludedGroupList:
             #     packages.append('--exclude=@%s' % group.name)
 
             for pkg in ksparser.handler.packages.excludedList:
-                packages.append('--exclude=%s' % pkg)
+                packages.append("--exclude=%s" % pkg)
 
             try:
-                with open(args.extract_packages_to, 'w') as pkgs_fd:
-                    pkgs_fd.write(' '.join(packages))
+                with open(args.extract_packages_to, "w") as pkgs_fd:
+                    pkgs_fd.write(" ".join(packages))
             except EnvironmentError:
                 print("Cannot write packages list to %s" % args.extract_packages_to)
                 return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/qubesbuilder/plugins/installer/scripts/update-templates-cache
+++ b/qubesbuilder/plugins/installer/scripts/update-templates-cache
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2024 Frédéric Pierret (fepitre) <frederic@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e -o pipefail -u
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <orig_dir> <dest_dir>"
+  exit 1
+fi
+
+orig_dir="$1"
+dest_dir="$2"
+
+if [ ! -d "$orig_dir" ]; then
+  echo "ERROR: Directory $orig_dir does not exist."
+  exit 1
+fi
+
+if [ ! -d "$dest_dir" ]; then
+  echo "ERROR: Directory $dest_dir does not exist."
+  exit 1
+fi
+
+read -r -a TEMPLATE_PACKAGES <<< "$TEMPLATE_PACKAGES"
+
+for template_name in "${TEMPLATE_PACKAGES[@]}"; do
+    for rpm_file in "$orig_dir"/"$template_name"-*.rpm; do
+        # Check if there are any files with the same base name in dest_dir
+        template_filename=$(basename "$rpm_file")
+        if [ ! -e "$dest_dir/$template_filename" ]; then
+            echo "INFO: Copying template $rpm_file into $dest_dir"
+            mv "$rpm_file" "$dest_dir/"
+        else
+            echo "INFO: Ignoring existing template $rpm_file into $dest_dir"
+        fi
+    done
+done
+
+find "$dest_dir" -name "$template_name-*.rpm" | \
+sort -r | \
+tail -n +2 | \
+xargs -I '{}' rm -f '{}'

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -25,7 +25,12 @@ from pathlib import Path
 
 from dateutil.parser import parse as parsedate
 
-from qubesbuilder.config import Config, QUBES_RELEASE_RE, QUBES_RELEASE_DEFAULT
+from qubesbuilder.config import (
+    Config,
+    QUBES_RELEASE_RE,
+    QUBES_RELEASE_DEFAULT,
+    ConfigError,
+)
 from qubesbuilder.executors import ExecutorError
 from qubesbuilder.executors.local import LocalExecutor
 from qubesbuilder.pluginmanager import PluginManager
@@ -87,11 +92,10 @@ class TemplateBuilderPlugin(TemplatePlugin):
 
     def get_template_version(self):
         if not self.template_version:
-            parsed_release = QUBES_RELEASE_RE.match(
-                self.config.qubes_release
-            ) or QUBES_RELEASE_RE.match(QUBES_RELEASE_DEFAULT)
-            if not parsed_release:
-                raise TemplateError(f"Cannot parse template version.")
+            try:
+                parsed_release = self.config.parse_qubes_release()
+            except ConfigError as e:
+                raise TemplateError(f"Cannot parse template version: {str(e)}") from e
             # For now, we assume 4.X.0
             self.template_version = f"{parsed_release.group(1)}.0"
         return self.template_version

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -93,6 +93,9 @@ templates:
   - fedora-40-xfce:
       dist: fc40
       flavor: xfce
+  - fedora-40-minimal:
+      dist: fc40
+      flavor: minimal
   - centos-stream-8:
       dist: centos-stream8
   - debian-12:

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -41,6 +41,8 @@ cache:
   vm-bookworm:
     packages:
       - quilt
+  templates-itl:
+    - debian-12-minimal
 
 distributions:
   - host-fc37
@@ -65,6 +67,7 @@ components:
       packages: False
   - qubes-release:
       packages: False
+      branch: release4.2
   - template-whonix:
       packages: False
       url: https://github.com/Whonix/qubes-template-whonix

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2414,3 +2414,25 @@ def test_template_debian_12_minimal_publish(artifacts_dir):
         assert repomd_hash in (metadata_dir / "repomd.xml.metalink").read_text(
             encoding="ascii"
         )
+
+
+def test_installer_init_cache(artifacts_dir):
+    env = os.environ.copy()
+    templates_cache = artifacts_dir / "cache/installer/templates"
+
+    qb_call(
+        DEFAULT_BUILDER_CONF, artifacts_dir, "-c", "qubes-release", "package", "fetch"
+    )
+
+    # make ISO cache
+    qb_call(
+        DEFAULT_BUILDER_CONF,
+        artifacts_dir,
+        "installer",
+        "init-cache",
+        env=env,
+    )
+
+    rpms = list(templates_cache.glob("*.rpm"))
+    assert rpms
+    assert rpms[0].name.startswith("qubes-template-debian-12-minimal-4.2.0")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1794,11 +1794,11 @@ repository-upload-remote-host:
 
 
 #
-# Pipeline for Fedora 40 XFCE template
+# Pipeline for Fedora 40  template
 #
 
 
-def test_template_fedora_40_xfce_prep(artifacts_dir):
+def test_template_fedora_40_prep(artifacts_dir):
     qb_call(
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
@@ -1814,42 +1814,42 @@ def test_template_fedora_40_xfce_prep(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-t",
-        "fedora-40-xfce",
+        "fedora-40-minimal",
         "template",
         "prep",
     )
 
-    assert (artifacts_dir / "templates/build_timestamp_fedora-40-xfce").exists()
+    assert (artifacts_dir / "templates/build_timestamp_fedora-40-minimal").exists()
     assert (
-        artifacts_dir / "templates/qubeized_images/fedora-40-xfce/root.img"
+        artifacts_dir / "templates/qubeized_images/fedora-40-minimal/root.img"
     ).exists()
-    assert (artifacts_dir / "templates/fedora-40-xfce/appmenus").exists()
-    assert (artifacts_dir / "templates/fedora-40-xfce/template.conf").exists()
+    assert (artifacts_dir / "templates/fedora-40-minimal/appmenus").exists()
+    assert (artifacts_dir / "templates/fedora-40-minimal/template.conf").exists()
 
 
-def test_template_fedora_40_xfce_build(artifacts_dir):
+def test_template_fedora_40_build(artifacts_dir):
     qb_call(
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-t",
-        "fedora-40-xfce",
+        "fedora-40-minimal",
         "template",
         "build",
     )
 
-    assert (artifacts_dir / "templates/build_timestamp_fedora-40-xfce").exists()
+    assert (artifacts_dir / "templates/build_timestamp_fedora-40-minimal").exists()
 
-    with open(artifacts_dir / "templates/build_timestamp_fedora-40-xfce") as f:
+    with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal") as f:
         data = f.read().splitlines()
     template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%M")
     rpm_path = (
         artifacts_dir
-        / f"templates/rpm/qubes-template-fedora-40-xfce-4.2.0-{template_timestamp}.noarch.rpm"
+        / f"templates/rpm/qubes-template-fedora-40-minimal-4.2.0-{template_timestamp}.noarch.rpm"
     )
     assert rpm_path.exists()
 
 
-def test_template_fedora_40_xfce_sign(artifacts_dir):
+def test_template_fedora_40_minimal_sign(artifacts_dir):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/.gnupg"
@@ -1866,7 +1866,7 @@ def test_template_fedora_40_xfce_sign(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "template",
             "sign",
             env=env,
@@ -1875,12 +1875,12 @@ def test_template_fedora_40_xfce_sign(artifacts_dir):
     dbpath = artifacts_dir / "templates/rpmdb"
     assert dbpath.exists()
 
-    with open(artifacts_dir / "templates/build_timestamp_fedora-40-xfce") as f:
+    with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal") as f:
         data = f.read().splitlines()
     template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%M")
     rpm_path = (
         artifacts_dir
-        / f"templates/rpm/qubes-template-fedora-40-xfce-4.2.0-{template_timestamp}.noarch.rpm"
+        / f"templates/rpm/qubes-template-fedora-40-minimal-4.2.0-{template_timestamp}.noarch.rpm"
     )
     assert rpm_path.exists()
     result = subprocess.run(
@@ -1892,7 +1892,7 @@ def test_template_fedora_40_xfce_sign(artifacts_dir):
     assert "digests signatures OK" in result.stdout.decode()
 
 
-def test_template_fedora_40_xfce_publish(artifacts_dir):
+def test_template_fedora_40_minimal_publish(artifacts_dir):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/.gnupg"
@@ -1907,17 +1907,17 @@ def test_template_fedora_40_xfce_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "repository",
             "publish",
             "templates-itl-testing",
             env=env,
         )
 
-        with open(artifacts_dir / "templates/fedora-40-xfce.publish.yml") as f:
+        with open(artifacts_dir / "templates/fedora-40-minimal.publish.yml") as f:
             info = yaml.safe_load(f.read())
 
-        with open(artifacts_dir / "templates/build_timestamp_fedora-40-xfce") as f:
+        with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal") as f:
             data = f.read().splitlines()
         template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%M")
 
@@ -1928,7 +1928,7 @@ def test_template_fedora_40_xfce_publish(artifacts_dir):
 
         # publish into templates-itl
         fake_time = (datetime.utcnow() - timedelta(days=7)).strftime("%Y%m%d%H%M")
-        publish_file = artifacts_dir / "templates/fedora-40-xfce.publish.yml"
+        publish_file = artifacts_dir / "templates/fedora-40-minimal.publish.yml"
 
         for r in info["repository-publish"]:
             if r["name"] == "templates-itl-testing":
@@ -1942,7 +1942,7 @@ def test_template_fedora_40_xfce_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "repository",
             "publish",
             "templates-itl",
@@ -1959,7 +1959,7 @@ def test_template_fedora_40_xfce_publish(artifacts_dir):
 
     # Check that packages are in the published repository
     for repository in ["templates-itl-testing", "templates-itl"]:
-        rpm = f"qubes-template-fedora-40-xfce-4.2.0-{template_timestamp}.noarch.rpm"
+        rpm = f"qubes-template-fedora-40-minimal-4.2.0-{template_timestamp}.noarch.rpm"
         repository_dir = (
             f"file://{artifacts_dir}/repository-publish/rpm/r4.2/{repository}"
         )
@@ -1978,8 +1978,8 @@ def test_template_fedora_40_xfce_publish(artifacts_dir):
         )
 
 
-# @pytest.mark.depends(on=['test_template_publish_fedora_40_xfce'])
-def test_template_fedora_40_xfce_publish_new(artifacts_dir):
+# @pytest.mark.depends(on=['test_template_publish_fedora_40_minimal'])
+def test_template_fedora_40_minimal_publish_new(artifacts_dir):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/.gnupg"
@@ -1989,7 +1989,7 @@ def test_template_fedora_40_xfce_publish_new(artifacts_dir):
         env["GNUPGHOME"] = gnupghome
         env["HOME"] = tmpdir
 
-        with open(artifacts_dir / "templates/build_timestamp_fedora-40-xfce") as f:
+        with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal") as f:
             data = f.read().splitlines()
         template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%M")
 
@@ -1997,14 +1997,14 @@ def test_template_fedora_40_xfce_publish_new(artifacts_dir):
         new_timestamp = (parsedate(data[0]) + timedelta(minutes=1)).strftime(
             "%Y%m%d%H%M"
         )
-        with open(artifacts_dir / "templates/build_timestamp_fedora-40-xfce", "w") as f:
+        with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal", "w") as f:
             f.write(new_timestamp)
 
         qb_call(
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "template",
             "build",
             "sign",
@@ -2013,7 +2013,7 @@ def test_template_fedora_40_xfce_publish_new(artifacts_dir):
 
         rpm_path = (
             artifacts_dir
-            / f"templates/rpm/qubes-template-fedora-40-xfce-4.2.0-{new_timestamp}.noarch.rpm"
+            / f"templates/rpm/qubes-template-fedora-40-minimal-4.2.0-{new_timestamp}.noarch.rpm"
         )
         assert rpm_path.exists()
 
@@ -2024,14 +2024,14 @@ def test_template_fedora_40_xfce_publish_new(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "repository",
             "publish",
             "templates-itl-testing",
             env=env,
         )
 
-        publish_file = artifacts_dir / "templates/fedora-40-xfce.publish.yml"
+        publish_file = artifacts_dir / "templates/fedora-40-minimal.publish.yml"
         with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
@@ -2056,7 +2056,7 @@ def test_template_fedora_40_xfce_publish_new(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "repository",
             "publish",
             "templates-itl",
@@ -2074,8 +2074,8 @@ def test_template_fedora_40_xfce_publish_new(artifacts_dir):
     # Check that packages are in the published repository
     for repository in ["templates-itl-testing", "templates-itl"]:
         rpms = {
-            f"qubes-template-fedora-40-xfce-4.2.0-{template_timestamp}.noarch.rpm",
-            f"qubes-template-fedora-40-xfce-4.2.0-{new_timestamp}.noarch.rpm",
+            f"qubes-template-fedora-40-minimal-4.2.0-{template_timestamp}.noarch.rpm",
+            f"qubes-template-fedora-40-minimal-4.2.0-{new_timestamp}.noarch.rpm",
         }
         repository_dir = (
             f"file://{artifacts_dir}/repository-publish/rpm/r4.2/{repository}"
@@ -2095,7 +2095,7 @@ def test_template_fedora_40_xfce_publish_new(artifacts_dir):
         )
 
 
-def test_template_fedora_40_xfce_unpublish(artifacts_dir):
+def test_template_fedora_40_minimal_unpublish(artifacts_dir):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/.gnupg"
@@ -2105,7 +2105,7 @@ def test_template_fedora_40_xfce_unpublish(artifacts_dir):
         env["GNUPGHOME"] = gnupghome
         env["HOME"] = tmpdir
 
-        with open(artifacts_dir / "templates/build_timestamp_fedora-40-xfce") as f:
+        with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal") as f:
             data = f.read().splitlines()
         template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%M")
 
@@ -2114,14 +2114,14 @@ def test_template_fedora_40_xfce_unpublish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "repository",
             "unpublish",
             "templates-itl",
             env=env,
         )
 
-        publish_file = artifacts_dir / "templates/fedora-40-xfce.publish.yml"
+        publish_file = artifacts_dir / "templates/fedora-40-minimal.publish.yml"
         with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
@@ -2132,7 +2132,7 @@ def test_template_fedora_40_xfce_unpublish(artifacts_dir):
 
     # Check that packages are in the published repository
     for repository in ["templates-itl-testing", "templates-itl"]:
-        rpm = f"qubes-template-fedora-40-xfce-4.2.0-{template_timestamp}.noarch.rpm"
+        rpm = f"qubes-template-fedora-40-minimal-4.2.0-{template_timestamp}.noarch.rpm"
         repository_dir = (
             f"file://{artifacts_dir}/repository-publish/rpm/r4.2/{repository}"
         )
@@ -2161,10 +2161,10 @@ def test_template_fedora_40_xfce_unpublish(artifacts_dir):
 def test_template_fedora_for_iso(artifacts_dir):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(artifacts_dir / "templates/build_timestamp_fedora-40-xfce") as f:
+        with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal") as f:
             data = f.read().splitlines()
         template_timestamp = parsedate(data[0]).strftime("%Y%m%d%H%M")
-        rpm = f"qubes-template-fedora-40-xfce-4.2.0-{template_timestamp}.noarch.rpm"
+        rpm = f"qubes-template-fedora-40-minimal-4.2.0-{template_timestamp}.noarch.rpm"
 
         qb_call(
             DEFAULT_BUILDER_CONF,
@@ -2185,7 +2185,7 @@ def test_template_fedora_for_iso(artifacts_dir):
             kickstart_f.write(
                 """
 %packages
-qubes-template-fedora-40-xfce
+qubes-template-fedora-40-minimal
 %end
 """
             )
@@ -2195,7 +2195,7 @@ qubes-template-fedora-40-xfce
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "fedora-40-xfce",
+            "fedora-40-minimal",
             "-o",
             f"iso:kickstart={kickstart!s}",
             "installer",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,14 +155,15 @@ def _get_infos(artifacts_dir):
         "python-qasync",
         "app-linux-split-gpg",
     ]:
+        qb_file = artifacts_dir / "sources" / component / ".qubesbuilder"
         dir_fd = os.open(artifacts_dir / "sources" / component, os.O_RDONLY)
-        infos[component] = {
-            "inodes": os.stat(
-                artifacts_dir / "sources" / component / ".qubesbuilder"
-            ).st_ino,
-            "fd": dir_fd,
-            "list": os.listdir(dir_fd),
-        }
+        btime = subprocess.run(
+            ["stat", "-c", "%W", str(qb_file)],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        infos[component] = {"btime": btime, "fd": dir_fd, "list": os.listdir(dir_fd)}
     return infos
 
 
@@ -215,7 +216,7 @@ def test_common_component_fetch_updating(artifacts_dir):
     infos_after = _get_infos(artifacts_dir)
 
     for component in infos_before:
-        assert infos_after[component]["inodes"] != infos_before[component]["inodes"]
+        assert infos_after[component]["btime"] != infos_before[component]["btime"]
 
 
 def test_common_component_fetch_inplace(artifacts_dir):
@@ -272,7 +273,7 @@ def test_common_component_fetch_inplace_updating(artifacts_dir):
     infos_after = _get_infos(artifacts_dir)
 
     for component in infos_before:
-        assert infos_after[component]["inodes"] == infos_before[component]["inodes"]
+        assert infos_after[component]["btime"] == infos_before[component]["btime"]
         assert os.listdir(infos_after[component]["fd"]) == os.listdir(
             infos_before[component]["fd"]
         )
@@ -372,7 +373,9 @@ def test_component_host_fc37_build(artifacts_dir):
     srpm = "qubes-core-qrexec-4.2.18-1.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
+        assert (
+            artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm
+        ).exists()
 
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
@@ -392,7 +395,9 @@ def test_component_host_fc37_build(artifacts_dir):
     srpm = "qubes-core-qrexec-dom0-4.2.18-1.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
+        assert (
+            artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm
+        ).exists()
 
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
@@ -1467,7 +1472,9 @@ def test_increment_component_build(artifacts_dir):
     srpm = "qubes-core-qrexec-4.2.18-1.42.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
+        assert (
+            artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm
+        ).exists()
 
     rpms = {
         "qubes-core-qrexec-dom0-4.2.18-1.42.fc37.x86_64.rpm",
@@ -1477,7 +1484,9 @@ def test_increment_component_build(artifacts_dir):
     srpm = "qubes-core-qrexec-dom0-4.2.18-1.42.fc37.src.rpm"
 
     for rpm in rpms.union({srpm}):
-        assert (artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm).exists()
+        assert (
+            artifacts_dir / "repository/host-fc37/core-qrexec_4.2.18" / rpm
+        ).exists()
 
     deb_files = [
         "libqrexec-utils-dev_4.2.18-1+deb12u1+devel42_amd64.deb",
@@ -1997,7 +2006,9 @@ def test_template_fedora_40_minimal_publish_new(artifacts_dir):
         new_timestamp = (parsedate(data[0]) + timedelta(minutes=1)).strftime(
             "%Y%m%d%H%M"
         )
-        with open(artifacts_dir / "templates/build_timestamp_fedora-40-minimal", "w") as f:
+        with open(
+            artifacts_dir / "templates/build_timestamp_fedora-40-minimal", "w"
+        ) as f:
             f.write(new_timestamp)
 
         qb_call(
@@ -2158,6 +2169,7 @@ def test_template_fedora_40_minimal_unpublish(artifacts_dir):
 # Pipeline for providing template to ISO build
 #
 
+
 def test_template_fedora_for_iso(artifacts_dir):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -2172,11 +2184,12 @@ def test_template_fedora_for_iso(artifacts_dir):
             "-c",
             "qubes-release",
             "package",
-            "fetch"
+            "fetch",
         )
 
         default_kickstart = (
-            artifacts_dir / "sources/qubes-release/conf/iso-online-testing-no-templates.ks"
+            artifacts_dir
+            / "sources/qubes-release/conf/iso-online-testing-no-templates.ks"
         )
 
         kickstart = tmpdir + "/tests-kickstart.cfg"
@@ -2218,6 +2231,7 @@ qubes-template-fedora-40-minimal
             / "x86_64/os/Packages"
         )
         assert (installer_iso_pkgs / rpm).exists()
+
 
 #
 # Pipeline for Debian 12 minimal template

--- a/tests/test_cli_repository.py
+++ b/tests/test_cli_repository.py
@@ -155,9 +155,10 @@ def test_repository_create_template(artifacts_dir):
         assert repomd_hash in (metadata_dir / "repomd.xml.metalink").read_text(
             encoding="ascii"
         )
-        assert (
-            "/pub/os/qubes/repo/yum/r4.2/templates-community-testing/repodata/repomd.xml"
-            in (metadata_dir / "repomd.xml.metalink").read_text(encoding="ascii")
+        assert "/pub/os/qubes/repo/yum/r4.2/templates-community-testing/repodata/repomd.xml" in (
+            metadata_dir / "repomd.xml.metalink"
+        ).read_text(
+            encoding="ascii"
         )
 
         qb_call(

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -191,7 +191,9 @@ def test_local_simple():
     reason="Qubes Admin VM is required!",
 )
 def test_qubes_simple():
-    executor = LinuxQubesExecutor(os.environ.get("QUBES_EXECUTOR_DISPVM", "builder-dvm"))
+    executor = LinuxQubesExecutor(
+        os.environ.get("QUBES_EXECUTOR_DISPVM", "builder-dvm")
+    )
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create a local file with some content
         hello = Path(temp_dir) / "hello.md"
@@ -223,7 +225,9 @@ def test_qubes_simple():
     reason="Qubes Admin VM is required!",
 )
 def test_qubes_environment():
-    executor = LinuxQubesExecutor(os.environ.get("QUBES_EXECUTOR_DISPVM", "builder-dvm"))
+    executor = LinuxQubesExecutor(
+        os.environ.get("QUBES_EXECUTOR_DISPVM", "builder-dvm")
+    )
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create a local file with some content
         hello = Path(temp_dir) / "hello.md"


### PR DESCRIPTION
This PR allows to create a template cache in the `init-cache` phase of `installer` plugin. In the `builder.yml`, it looks like:

```
cache:
  templates-itl:
    - fedora-39-xfce
    - debian-12-xfce
  templates-community:
    - whonix-gateway-17
    - whonix-workstation-17
```

If `use-qubes-repo` with `testing` is set, then it would enable also corresponding testing repositories for templates.

Dependencies update for executor:
```
- pykickstart
```