### PR TITLE
Fix caching for packages having special chars for bash

### DIFF
--- a/qubesbuilder/plugins/chroot_rpm/__init__.py
+++ b/qubesbuilder/plugins/chroot_rpm/__init__.py
@@ -145,7 +145,7 @@ class RPMChrootPlugin(RPMDistributionPlugin, ChrootPlugin):
                 )
             ]
             for package in additional_packages:
-                mock_cmd += ["--install", package]
+                mock_cmd += ["--install", f"'{package}'"]
             cmd.append(" ".join(mock_cmd))
             try:
                 executor.run(


### PR DESCRIPTION
Closes QubesOS/qubes-issues#9322