### PR TITLE
Fix having a submodule as a primary source

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,8 +397,10 @@ We provide the following list of available keys:
 - `modules` --- Declare submodules to be included inside source preparation
   (source archives creation and placeholders substitution)
 - `files` --- List of external files to be downloaded. It has to be provided
-  with the combination of a `url` and a verification method. A verification
-  method is either a checksum file or a signature file with public GPG keys.
+  with the combination of a `url`/`git-url` and a verification method. For
+  `url`, a verification method is either a checksum file or a signature file
+  with public GPG keys. For `git-url`, it's either GPG key to verity a tag, or
+  explicit commit id.
 - `url` --- URL of the external file to download.
 - `sha256` --- Path to `sha256` checksum file relative to source directory (in
   combination with `url`).
@@ -409,6 +411,15 @@ We provide the following list of available keys:
 - `uncompress` --- Uncompress external file downloaded before verification.
 - `pubkeys` --- List of public GPG keys to use for verifying the downloaded
   signature file (in combination with `url` and `signature`).
+- `git-url` --- URL of a repository to fetch and create a tarball from.
+- `tag` --- Specific tag to fetch from `git-url` and verify with a key
+  specified in `pubkeys`.  Can use `@VERSION@` placeholder.
+- `commit-id` --- Specific pre-verified commit to fetch from `git-url`. No
+  extra verification is performed.
+- `git-basename` --- Specify basename for archive created out of git
+  repository. This is also used for the top level directory inside the archive.
+  If not set, final component of the `git-url` (minus `.git` if applicable),
+  plus a commit id or tag will be used.
 
 Here is a non-exhaustive list of distribution-specific keys:
 - `host-fc32` --- Fedora 32 for the `host` package set content only

--- a/qubesbuilder/common.py
+++ b/qubesbuilder/common.py
@@ -16,6 +16,7 @@
 # with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+import os
 import re
 import shutil
 import tempfile
@@ -74,6 +75,13 @@ def is_filename_valid(
         if c not in authorized_chars:
             return False
     return True
+
+
+def get_archive_name(file: dict):
+    fn = os.path.basename(file["url"])
+    if file.get("uncompress", False):
+        return Path(fn).with_suffix("").name
+    return fn
 
 
 # Originally from QubesOS/qubes-builder/rpc-services/qubesbuilder.BuildLog

--- a/qubesbuilder/common.py
+++ b/qubesbuilder/common.py
@@ -78,10 +78,21 @@ def is_filename_valid(
 
 
 def get_archive_name(file: dict):
-    fn = os.path.basename(file["url"])
-    if file.get("uncompress", False):
-        return Path(fn).with_suffix("").name
-    return fn
+    if "url" in file:
+        fn = os.path.basename(file["url"])
+        if file.get("uncompress", False):
+            return Path(fn).with_suffix("").name
+        return fn
+    if "git-basename" in file:
+        return f"{file['git-basename']}.tar.gz"
+    else:
+        archive_base = os.path.basename(file["git-url"]).partition(".git")[0]
+        if "tag" in file:
+            assert "/" not in file["tag"]
+            return f"{archive_base}-{file['tag']}.tar.gz"
+        if "commit-id" in file:
+            return f"{archive_base}-{file['commit-id']}.tar.gz"
+    return None
 
 
 # Originally from QubesOS/qubes-builder/rpc-services/qubesbuilder.BuildLog

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
@@ -79,7 +79,7 @@ def verify_git_obj(gpg_client, keyring_dir, repository_dir, obj_type, obj_path):
 
 def main(args):
     # Sanity check on branch and repo
-    if not re.match(r"^[A-Za-z][A-Za-z0-9/._-]+$", args.git_branch):
+    if not re.match(r"^[A-Za-z0-9][A-Za-z0-9/._-]+$", args.git_branch):
         raise ValueError(f"Invalid branch {args.git_branch}")
     elif not re.match(r"^/[A-Za-z][A-Za-z0-9-/_]*$", args.component_directory):
         raise ValueError(

--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source.py
@@ -91,7 +91,7 @@ def main(args):
     keys_dir = Path(args.keys_dir).expanduser().resolve()
     git_keyring_dir = Path(args.git_keyring_dir).expanduser().resolve()
 
-    git_branch = args.git_branch
+    git_branch = args.git_commit or args.git_branch
     clean = args.clean
     fetch_only = args.fetch_only
     ignore_missing = args.ignore_missing
@@ -120,9 +120,17 @@ def main(args):
         if not re.match(r"^[a-fA-F0-9]{40}$", maintainer):
             raise ValueError(f"Invalid maintainer provided: {maintainer}")
 
+    if args.trust_all_keys and maintainers:
+        raise ValueError(
+            "--maintainer cannot be used together with --trust-all-keys"
+        )
+
     # Define common git options
     git_options: List[str] = []
     git_merge_opts = ["--ff-only"]
+
+    if args.shallow_clone:
+        git_options += ["--depth=1"]
 
     fresh_clone = False
     if clean:
@@ -173,20 +181,38 @@ def main(args):
         if repo.exists():
             shutil.rmtree(repo)
         try:
-            subprocess.run(
-                [
-                    "git",
-                    "clone",
-                    "-n",
-                    "-q",
-                    "-b",
-                    git_branch,
-                    git_url,
-                    str(repo),
-                ],
-                capture_output=True,
-                check=True,
-            )
+            if args.git_commit:
+                # git clone can't handle commit reference, use fetch instead
+                repo.mkdir()
+                subprocess.run(
+                    ["git", "init"],
+                    capture_output=True,
+                    cwd=repo,
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "fetch"]
+                    + git_options
+                    + ["--", git_url, git_branch],
+                    capture_output=True,
+                    cwd=repo,
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "reset", "-q", "--soft", "FETCH_HEAD"],
+                    capture_output=True,
+                    cwd=repo,
+                    check=True,
+                )
+            else:
+                subprocess.run(
+                    ["git", "clone"]
+                    + git_options
+                    + ["-n", "-q", "-b", git_branch]
+                    + ["--", git_url, str(repo)],
+                    capture_output=True,
+                    check=True,
+                )
         except subprocess.CalledProcessError as e:
             if ignore_missing:
                 return
@@ -220,6 +246,9 @@ def main(args):
         verify = False
     elif less_secure_signed_commits_sufficient:
         check = "signed-tag-or-commit"
+    elif args.git_commit:
+        # user specified pre-verified commit-id
+        verify = False
 
     verify_ref = subprocess.run(
         ["git", "rev-parse", "-q", "--verify", verify_ref],
@@ -250,6 +279,33 @@ def main(args):
             check=True,
             env=env,
         )
+        if args.trust_all_keys:
+            for file in keys_dir.glob("*"):
+                subprocess.run(
+                    [gpg_client, "--import", str(file)],
+                    check=True,
+                    env=env,
+                    capture_output=True,
+                )
+            list_keys = subprocess.run(
+                [gpg_client, "--list-keys", "--with-colons"],
+                capture_output=True,
+                check=True,
+                env=env,
+            )
+            for line in list_keys.stdout.splitlines():
+                if not line.startswith(b"fpr:"):
+                    continue
+                keyid = line.decode().split(":")[9]
+                subprocess.run(
+                    [gpg_client, "--import-ownertrust"],
+                    input=f"{keyid}:6:\n",
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    check=True,
+                )
+
         for keyid in maintainers:
             key_path = keys_dir / f"{keyid}.asc"
             if not key_path.exists():
@@ -469,9 +525,18 @@ def get_args():
     # optional args
     parser.add_argument("--git-branch", help="Git branch.", default="main")
     parser.add_argument(
+        "--git-commit",
+        help="Specific git commit id - full sha. Takes precedence over branch and does not require signed tag.",
+    )
+    parser.add_argument(
         "--clean",
         action="store_true",
         help="Remove previous sources (use git up vs git clone).",
+    )
+    parser.add_argument(
+        "--shallow-clone",
+        action="store_true",
+        help="Fetch git repo with --depth=1 to reduce amount of data.",
     )
     parser.add_argument(
         "--fetch-only",
@@ -502,6 +567,11 @@ def get_args():
         "--maintainer",
         action="append",
         help="Allowed maintainer provided as KEYID assumed to be available as KEYID.asc under provided 'keys-dir' directory. Can be used multiple times.",
+    )
+    parser.add_argument(
+        "--trust-all-keys",
+        action="store_true",
+        help="Import and trust all keys present in *keys-dir*. Conflicts with --maintainer.",
     )
     parser.add_argument(
         "--minimum-distinct-maintainers",

--- a/qubesbuilder/plugins/source_deb/__init__.py
+++ b/qubesbuilder/plugins/source_deb/__init__.py
@@ -22,7 +22,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from qubesbuilder.common import is_filename_valid
+from qubesbuilder.common import is_filename_valid, get_archive_name
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
@@ -192,7 +192,7 @@ class DEBSourcePlugin(DEBDistributionPlugin, SourcePlugin):
                 source_debian = f"{package_release_name_full}.debian.tar.xz"
             if parameters.get("files", []):
                 # FIXME: The first file is the source archive. Is it valid for all the cases?
-                ext = Path(parameters["files"][0]["url"]).suffix
+                ext = Path(get_archive_name(parameters["files"][0])).suffix
                 msg = f"{self.component}:{self.dist}:{directory}: Invalid extension '{ext}'."
                 if ext not in (".gz", ".bz2", ".xz", ".lzma2"):
                     raise SourceError(msg)
@@ -260,7 +260,7 @@ class DEBSourcePlugin(DEBDistributionPlugin, SourcePlugin):
                         f"mv {source_dir}/{source_orig} {executor.get_builder_dir()}",
                     ]
                 for file in parameters.get("files", []):
-                    fn = os.path.basename(file["url"])
+                    fn = get_archive_name(file)
                     cmd.append(
                         f"mv {executor.get_distfiles_dir() / self.component.name / fn} {executor.get_builder_dir()}/{source_orig}"
                     )

--- a/qubesbuilder/plugins/source_rpm/__init__.py
+++ b/qubesbuilder/plugins/source_rpm/__init__.py
@@ -22,7 +22,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from qubesbuilder.common import is_filename_valid
+from qubesbuilder.common import is_filename_valid, get_archive_name
 from qubesbuilder.component import QubesComponent
 from qubesbuilder.config import Config
 from qubesbuilder.distribution import QubesDistribution
@@ -263,9 +263,7 @@ class RPMSourcePlugin(RPMDistributionPlugin, SourcePlugin):
                     ]
 
             for file in parameters.get("files", []):
-                fn = os.path.basename(file["url"])
-                if file.get("uncompress", False):
-                    fn = Path(fn).with_suffix("").name
+                fn = get_archive_name(file)
                 cmd.append(
                     f"mv {executor.get_distfiles_dir() / self.component.name / fn} {source_dir}"
                 )

--- a/qubesbuilder/plugins/source_rpm/__init__.py
+++ b/qubesbuilder/plugins/source_rpm/__init__.py
@@ -125,6 +125,10 @@ class RPMSourcePlugin(RPMDistributionPlugin, SourcePlugin):
             shutil.rmtree(artifacts_dir.as_posix())
         artifacts_dir.mkdir(parents=True)
 
+        # Create archive only if no external files are provided or if explicitly requested.
+        create_archive = not parameters.get("files", [])
+        create_archive = parameters.get("create-archive", create_archive)
+
         for build in parameters["build"]:
             # Temporary dir for temporary copied-out files
             temp_dir = Path(tempfile.mkdtemp())
@@ -177,15 +181,19 @@ class RPMSourcePlugin(RPMDistributionPlugin, SourcePlugin):
                 raise SourceError(msg)
 
             source_rpm = f"{data[0]}.src.rpm"
-            # Source0 may contain a URL.
-            source_orig = os.path.basename(data[1])
             if not is_filename_valid(
                 source_rpm, forbidden_filename=artifacts_info_filename
-            ) or not is_filename_valid(
-                source_orig, forbidden_filename=artifacts_info_filename
             ):
-                msg = f"{self.component}:{self.dist}:{build}: Invalid source names."
+                msg = f"{self.component}:{self.dist}:{build}: Invalid source rpm name."
                 raise SourceError(msg)
+            if create_archive:
+                # Source0 may contain a URL.
+                source_orig = os.path.basename(data[1])
+                if not is_filename_valid(
+                    source_orig, forbidden_filename=artifacts_info_filename
+                ):
+                    msg = f"{self.component}:{self.dist}:{build}: Invalid source names."
+                    raise SourceError(msg)
 
             # Read packages list
             packages_list = []
@@ -247,9 +255,6 @@ class RPMSourcePlugin(RPMDistributionPlugin, SourcePlugin):
                     f"--outfile {source_dir}/Makefile.vars -- "
                     f"{executor.get_plugins_dir()}/source/salt/FORMULA-DEFAULTS {source_dir}/FORMULA"
                 ]
-            # Create archive only if no external files are provided or if explicitly requested.
-            create_archive = not parameters.get("files", [])
-            create_archive = parameters.get("create-archive", create_archive)
             if create_archive:
                 # If no Source0 is provided, we expect 'source' from query-spec.
                 if source_orig != "source":

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -89,6 +89,10 @@ components:
       - 0064428F455451B3EBE78A7F063938BA42CFA724
       - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
       - C4A2E4615A16BD191110DEE17320B2D2134763F3
+  - linux-gbulb:
+      url: https://github.com/marmarek/qubes-linux-gbulb
+      branch: files-git
+      verification-mode: less-secure-signed-commits-sufficient
 
 templates:
   - fedora-40-xfce:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,21 @@ def test_common_component_fetch(artifacts_dir):
         artifacts_dir
         / "distfiles/desktop-linux-xfce4-xfwm4/xfwm4-4.16.1.tar.bz2"
     ).exists()
+    assert (
+        artifacts_dir
+        / "distfiles/linux-gbulb/gbulb-0.6.3.tar.gz"
+    ).exists()
+    # verify files layout inside
+    subprocess.run(
+        ["tar",
+         "tf",
+         artifacts_dir / "distfiles/linux-gbulb/gbulb-0.6.3.tar.gz",
+         "gbulb-0.6.3/README.rst"
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
     for component in [
         "core-qrexec",

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,7 +1,8 @@
 import pytest
 import tempfile
 from pathlib import Path
-from qubesbuilder.common import is_filename_valid, deep_check, sed
+from qubesbuilder.common import is_filename_valid, deep_check, sed, \
+    get_archive_name
 from qubesbuilder.cli.cli_main import parse_config_from_cli
 
 
@@ -264,3 +265,24 @@ def test_sed_without_destination():
         # Clean up the temporary file
         source_file.close()
         Path(source_file.name).unlink()
+
+
+def test_get_archive_name_url():
+    file = {
+        "url": "https://example.com/some-file.tar.gz",
+        "signature": "https://example.com/some-file.tar.gz.asc",
+        "pubkeys": ["pubkey1.asc", "pubkey2.asc"],
+    }
+    fn = get_archive_name(file)
+    assert fn == "some-file.tar.gz"
+
+
+def test_get_archive_name_url_uncompress():
+    file = {
+        "url": "https://example.com/some-file.tar.gz",
+        "signature": "https://example.com/some-file.tar.gz.asc",
+        "uncompress": True,
+        "pubkeys": ["pubkey1.asc", "pubkey2.asc"],
+    }
+    fn = get_archive_name(file)
+    assert fn == "some-file.tar"

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -286,3 +286,28 @@ def test_get_archive_name_url_uncompress():
     }
     fn = get_archive_name(file)
     assert fn == "some-file.tar"
+
+
+def test_get_archive_name_git_url():
+    file = {
+        "git-url": "https://github.com/owner/repo.git",
+        "tag": "v1.0.0",
+        "pubkeys": ["pubkey1.asc", "pubkey2.asc"],
+    }
+    fn = get_archive_name(file)
+    assert fn == "repo-v1.0.0.tar.gz"
+
+    file = {
+        "git-url": "https://github.com/owner/repo",
+        "commit-id": "0011223344556677889900112233445566778899",
+    }
+    fn = get_archive_name(file)
+    assert fn == "repo-0011223344556677889900112233445566778899.tar.gz"
+
+    file = {
+        "git-url": "https://github.com/owner/repo",
+        "tag": "v2.0.0",
+        "git-basename": "repo-2.0.0"
+    }
+    fn = get_archive_name(file)
+    assert fn == "repo-2.0.0.tar.gz"


### PR DESCRIPTION
Do not try to interpret Source0 tag to build automatic tarball name, if
it isn't going to be created. This is especially relevant when Source0
points at a submodule archive (created via "modules" entry in
.qubesbuilder).

TODO:
- [x] add a test (with a package actually having `Source0: @something@`)
- [x] verify if Debian and/or Arch doesn't need similar change

Fixes QubesOS/qubes-issues#9088