### PR TITLE
Enable setting a ssh-based baseurl in config

### DIFF
--- a/example-configs/archlinux.yml
+++ b/example-configs/archlinux.yml
@@ -1,5 +1,5 @@
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: qubesos/qubes-
   branch: main
 

--- a/example-configs/builder-devel.yml
+++ b/example-configs/builder-devel.yml
@@ -1,5 +1,5 @@
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: fepitre/qubes-
   branch: builderv2
   maintainers:

--- a/example-configs/gentoo.yml
+++ b/example-configs/gentoo.yml
@@ -1,5 +1,5 @@
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: qubesos/qubes-
   branch: main
 

--- a/example-configs/kali.yml
+++ b/example-configs/kali.yml
@@ -1,5 +1,5 @@
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: qubesos/qubes-
   branch: main
 

--- a/example-configs/qubes-os-main.yml
+++ b/example-configs/qubes-os-main.yml
@@ -1,7 +1,7 @@
 # Config for most recent development version ("main" aka "master" branch)
 
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: QubesOS/qubes-
   branch: main
   maintainers:

--- a/example-configs/qubes-os-r4.2-dom0.yml
+++ b/example-configs/qubes-os-r4.2-dom0.yml
@@ -5,7 +5,7 @@ include:
 #  - example-configs/github-maintainers.yml
 
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: QubesOS/qubes-
   branch: main
 

--- a/example-configs/qubes-os-r4.2.yml
+++ b/example-configs/qubes-os-r4.2.yml
@@ -1,5 +1,5 @@
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: QubesOS/qubes-
   branch: release4.2
   maintainers:

--- a/example-configs/qubes-os-r4.3-dom0.yml
+++ b/example-configs/qubes-os-r4.3-dom0.yml
@@ -4,7 +4,7 @@ include:
 #  - example-configs/github-maintainers.yml
 
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: QubesOS/qubes-
   branch: main
 

--- a/example-configs/qubes-os-r4.3.yml
+++ b/example-configs/qubes-os-r4.3.yml
@@ -1,5 +1,5 @@
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: QubesOS/qubes-
   branch: main
   maintainers:

--- a/example-configs/ubuntu.yml
+++ b/example-configs/ubuntu.yml
@@ -1,5 +1,5 @@
 git:
-  baseurl: https://github.com
+  baseurl: https://github.com/
   prefix: qubesos/qubes-
   branch: main
 

--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -492,7 +492,7 @@ class Config:
     def get_component_from_dict_or_string(
         self, component_name: Union[str, Dict]
     ) -> QubesComponent:
-        baseurl = self.get("git", {}).get("baseurl", "https://github.com")
+        baseurl = self.get("git", {}).get("baseurl", "https://github.com/")
         prefix = self.get("git", {}).get("prefix", "QubesOS/qubes-")
         suffix = self.get("git", {}).get("suffix", ".git")
         branch = self.get("git", {}).get("branch", "main")
@@ -505,7 +505,7 @@ class Config:
 
         name, options = next(iter(component_name.items()))
         source_dir = self.artifacts_dir / "sources" / name
-        url = f"{baseurl}/{options.get('prefix', prefix)}{name}{options.get('suffix', suffix)}"
+        url = f"{baseurl}{options.get('prefix', prefix)}{name}{options.get('suffix', suffix)}"
         verification_mode = VerificationMode.SignedTag
         if name in self._conf.get("insecure-skip-checking", []):
             verification_mode = VerificationMode.Insecure


### PR DESCRIPTION
Users might want to fetch sources from Github using SSH rather than HTTP. 

Sometimes they don't even have a choice, because when downloading large sources with a slow internet connection, HTTP will time out, thus aborting the fetch process. See [https://stackoverflow.com/questions/38618885/error-rpc-failed-curl-transfer-closed-with-outstanding-read-data-remaining](https://stackoverflow.com/questions/38618885/error-rpc-failed-curl-transfer-closed-with-outstanding-read-data-remaining) for example. The quickest solution seems to be downloading sources using SSH.

As for the current config, the separator between `baseurl` and `prefix` is hardcoded to be `/`, but we need it to be `:` in order to use a SSH connection. I suggest including this separator in `baseurl`, but it might be better to add a new config field for it, yet a bit cumbersome.

Examples of ssh baseurl as intended:
```yml
git:
  baseurl: git@github.com:
  prefix: QubesOS/qubes-
```

Tested with the qubes executor, adding Github ssh key in the disposable template, with no password.