### PR TITLE
arch: workaround "GPGME error: Inappropriate ioctl for device" issue

### DIFF
--- a/qubesbuilder/plugins/build_archlinux/__init__.py
+++ b/qubesbuilder/plugins/build_archlinux/__init__.py
@@ -371,6 +371,8 @@ class ArchlinuxBuildPlugin(ArchlinuxDistributionPlugin, BuildPlugin):
                 f"-d {executor.get_repository_dir()}:/builder/repository -- ",
                 f"--syncdeps --noconfirm --skipinteg",
             ]
+            # make stdout a pipe instead of pts, to not confuse gpgme
+            build_command += ["| cat"]
 
             cmd += [f"cd {source_dir}", " ".join(build_command)]
 

--- a/qubesbuilder/plugins/chroot_archlinux/__init__.py
+++ b/qubesbuilder/plugins/chroot_archlinux/__init__.py
@@ -81,7 +81,7 @@ def get_archchroot_cmd(
         "sudo pacman-key --init",
         "sudo pacman-key --populate",
         f"sudo mkdir -p {chroot_dir.parent}",
-        " ".join(mkarchchroot_cmd),
+        " ".join(mkarchchroot_cmd) + " | cat",
     ]
 
     return cmd


### PR DESCRIPTION
GPGME used by pacman tries very hard to configure terminal if it thinks
it can. When running inside docker, it results in a series of errors
like "GPGME error: Inappropriate ioctl for device", which then are
interpreted by pacman as signature verification failure.

Workaround this by adding " | cat" to pacman calls (or rather - scripts
that call pacman) to make stdout a pipe instead of pts. If it's stupid
but it works, it ain't stupid, right?

Related to QubesOS/qubes-issues#9193
And to many failures in CI