### PR TITLE
Allow all files and symlinks on copy-in into DispVM

### DIFF
--- a/rpc/qubesbuilder.FileCopyIn
+++ b/rpc/qubesbuilder.FileCopyIn
@@ -62,7 +62,8 @@ def main():
 
     # Run qfile-unpacker
     subprocess.run(
-        ["qfile-unpacker", str(uid), "/builder/incoming"], check=True, env=env
+        ["qfile-unpacker", "--allow-all-names", "--allow-unsafe-symlinks",
+         str(uid), "/builder/incoming"], check=True, env=env
     )
 
     # Move the file to the destination directory


### PR DESCRIPTION
There is no point in guarding DispVM from builder qube as the latter has
full control over the former anyway. Allow any files and symlinks when
copying in sources for building, in case somebody use some convenient
symlinks as part of their development tools.
But still strictly verify data received from a DispVM.