### PR TITLE
fetch: fix recursive submodule fetch

### DIFF
--- a/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
+++ b/qubesbuilder/plugins/fetch/scripts/get-and-verify-source
@@ -433,8 +433,7 @@ fi
 
 if [ -e .gitmodules ]; then
     echo -e "--> Updating submodules"
-    git submodule init || exit 1
-    git submodule update --recursive || exit 1
+    git submodule update --init --recursive || exit 1
 fi
 
 popd >/dev/null || exit 1


### PR DESCRIPTION
--recursive needs to be applied to submodule init too. Combine the two
into a single `git submodule update --init --recursive` call.