### PR TITLE
installer: make lorax use only pre-verified repo

### DIFF
--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -53,7 +53,7 @@ LORAX_PACKAGES := $(DNF_ROOT)/tmp/lorax_packages.list
 LORAX_OPTS := --product "Qubes OS" --variant "qubes" --macboot --force --rootfs-size=4
 LORAX_OPTS += --version "$(ISO_VERSION)" --release "Qubes OS $(ISO_VERSION)" --volid $(ISO_VOLID)
 LORAX_OPTS += --workdir $(INSTALLER_DIR)/work/work/x86_64 --logfile $(INSTALLER_DIR)/work/logs/lorax-x86_64.log
-LORAX_OPTS += --repo $(DNF_REPO) --skip-branding --disablerepo=fedora --disablerepo=fedora-updates --disablerepo=updates --disablerepo='qubes-*'
+LORAX_OPTS += --repo $(INSTALLER_DIR)/yum/lorax.repo --skip-branding --disablerepo=fedora --disablerepo=fedora-updates --disablerepo=updates --disablerepo='qubes-*'
 
 ifeq ($(ISO_USE_KERNEL_LATEST),1)
     LORAX_OPTS += --installpkgs kernel-latest --excludepkgs kernel

--- a/qubesbuilder/plugins/installer/mock/fedora-41-x86_64.cfg
+++ b/qubesbuilder/plugins/installer/mock/fedora-41-x86_64.cfg
@@ -1,0 +1,1 @@
+fedora-x86_64.cfg

--- a/qubesbuilder/plugins/installer/yum/lorax.repo
+++ b/qubesbuilder/plugins/installer/yum/lorax.repo
@@ -1,0 +1,10 @@
+[installer]
+name=installer
+enabled=1
+baseurl=file:///tmp/qubes-installer/yum/installer/
+gpgcheck=0
+[qubes-host]
+name=qubes-host
+enabled=1
+baseurl=file:///tmp/qubes-installer/yum/qubes-host/
+gpgcheck=0


### PR DESCRIPTION
The "prep" stage fetches all the packages and verifies them. Make lorax
use only that repo, instead of feeding it also source online
repositories. This avoid the need to patch lorax to ensure it verifies
package signatures in all the cases and so we can use upstream lorax
directly.

QubesOS/qubes-issues#9402