### PR TITLE
Improve Build Reproducibility for Core Admin Client 

### DIFF
--- a/qubesbuilder/plugins/build_deb/scripts/create-local-repo
+++ b/qubesbuilder/plugins/build_deb/scripts/create-local-repo
@@ -73,6 +73,7 @@ gzip -9c "dists/$SUITE/main/binary-amd64/Packages" > "dists/$SUITE/main/binary-a
 
 DATE=$(LC_ALL=C date -u +"%a, %d %b %Y %H:%M:%S %Z")
 
+
 cat > "dists/$SUITE/Release" <<EOF
 Label: Qubes builder repo
 Suite: $SUITE

--- a/qubesbuilder/plugins/build_rpm/scripts/rpmbuildinfo
+++ b/qubesbuilder/plugins/build_rpm/scripts/rpmbuildinfo
@@ -71,7 +71,6 @@ Version: $(rpm -qp --queryformat '%{version}-%{release}' "$SRPM")
 Architecture: $(rpm -qp --queryformat '%{arch}' "$SRPM")
 Binary: $(printf '%s' "$RPMS" | xargs rpm -qp --qf "%{name} ")
 Build-Origin: $(getos)
-Build-Date: $(date -R)
 Build-Path: $(rpm --eval '%{_builddir}')
 EOF
 

--- a/qubesbuilder/plugins/installer/Makefile
+++ b/qubesbuilder/plugins/installer/Makefile
@@ -26,7 +26,9 @@ INSTALLER_DIR ?= $(PLUGINS_DIR)/installer
 SOURCES_DIR ?= $(BUILDER_DIR)/sources
 INSTALLER_KICKSTART ?= $(SOURCES_DIR)/qubes-release/conf/qubes-kickstart.cfg
 CREATEREPO := $(shell which createrepo_c createrepo 2>/dev/null |head -1)
-ISO_VERSION ?= $(shell date +%Y%m%d)
+
+
+ISO_VERSION ?= $(shell date -d @"$(SOURCE_DATE_EPOCH)" +%Y%m%d 2>/dev/null || date +%Y%m%d)
 COMPS_FILE ?= $(SOURCES_DIR)/qubes-release/comps/comps-dom0.xml
 QUBES_VERSION ?= $(shell cat $(SOURCES_DIR)/qubes-release/version)
 

--- a/qubesbuilder/plugins/source_deb/scripts/clamp-changelog-entry-date
+++ b/qubesbuilder/plugins/source_deb/scripts/clamp-changelog-entry-date
@@ -22,6 +22,7 @@
 
 # Clamp the topmost changelog entry date ("Build for ...") to the previous one
 # (actual meaningful entry)
+#Reverted clamp-changelog-entry-date
 
 CHANGELOG_PATH="$1"
 
@@ -30,9 +31,14 @@ if [ ! -r "$CHANGELOG_PATH" ]; then
     exit 1
 fi
 
-# get previous date
-PREVIOUS_DATE=$(grep '^ --' "$CHANGELOG_PATH" | head -n 2 | tail -n 1 | grep -o '  .*')
+# Set CURRENT_DATE based on SOURCE_DATE_EPOCH or fallback to previous date
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
+    CURRENT_DATE=$(date -R -u -d "@$SOURCE_DATE_EPOCH")  # RFC 2822 format (e.g., Wed, 02 Oct 2002 15:00:00 +0200)
+else
+    # Get previous date from changelog
+    CURRENT_DATE=$(grep '^ --' "$CHANGELOG_PATH" | head -n 2 | tail -n 1 | grep -o '  .*')
+fi
 
-# replace topmost date
-sed -e "0,/^ --/s/^\( --.*\)\(  .*\)/\1$PREVIOUS_DATE/" -i "$CHANGELOG_PATH"
-touch --date="$PREVIOUS_DATE" "$CHANGELOG_PATH"
+# Replace the topmost date with CURRENT_DATE
+sed -e "0,/^ --/s/^\( --.*\)\(  .*\)/\1 $CURRENT_DATE/" -i "$CHANGELOG_PATH"
+touch --date="$CURRENT_DATE" "$CHANGELOG_PATH"

--- a/qubesbuilder/plugins/source_deb/scripts/clamp-changelog-entry-date
+++ b/qubesbuilder/plugins/source_deb/scripts/clamp-changelog-entry-date
@@ -31,14 +31,15 @@ if [ ! -r "$CHANGELOG_PATH" ]; then
     exit 1
 fi
 
-# Set CURRENT_DATE based on SOURCE_DATE_EPOCH or fallback to previous date
 if [ -n "$SOURCE_DATE_EPOCH" ]; then
-    CURRENT_DATE=$(date -R -u -d "@$SOURCE_DATE_EPOCH")  # RFC 2822 format (e.g., Wed, 02 Oct 2002 15:00:00 +0200)
+    # Use SOURCE_DATE_EPOCH as the reference if it's set
+    CURRENT_DATE=$(date -R -u -d "@$SOURCE_DATE_EPOCH")
 else
-    # Get previous date from changelog
+    # Get previous date from the changelog as a fallback
     CURRENT_DATE=$(grep '^ --' "$CHANGELOG_PATH" | head -n 2 | tail -n 1 | grep -o '  .*')
 fi
 
 # Replace the topmost date with CURRENT_DATE
-sed -e "0,/^ --/s/^\( --.*\)\(  .*\)/\1 $CURRENT_DATE/" -i "$CHANGELOG_PATH"
+sed -e "0,/^ --/s/^\( --.*\)\(  .*\)/\1$CURRENT_DATE/" -i "$CHANGELOG_PATH"
 touch --date="$CURRENT_DATE" "$CHANGELOG_PATH"
+

--- a/qubesbuilder/plugins/template/Makefile
+++ b/qubesbuilder/plugins/template/Makefile
@@ -45,7 +45,11 @@ fix_up := $(shell TEMPLATE_NAME=$(TEMPLATE_NAME) TEMPLATE_LABEL="$(TEMPLATE_LABE
 	$(BUILDER_DIR)/scripts/builder-fix-filenames)
 
 TEMPLATE_NAME := $(word 1,$(fix_up))
-TEMPLATE_TIMESTAMP ?= $(shell date -u +%Y%m%d%H%MZ)
+
+TEMPLATE_TIMESTAMP ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" +%Y%m%d%H%MZ 2>/dev/null || date -u +%Y%m%d%H%MZ)
+
+
+
 
 .PHONY: template-name prepare build build-rootimg build-rpm
 

--- a/qubesbuilder/plugins/template/Makefile
+++ b/qubesbuilder/plugins/template/Makefile
@@ -46,10 +46,7 @@ fix_up := $(shell TEMPLATE_NAME=$(TEMPLATE_NAME) TEMPLATE_LABEL="$(TEMPLATE_LABE
 
 TEMPLATE_NAME := $(word 1,$(fix_up))
 
-TEMPLATE_TIMESTAMP ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" +%Y%m%d%H%MZ 2>/dev/null || date -u +%Y%m%d%H%MZ)
-
-
-
+TEMPLATE_TIMESTAMP ?= $(shell date -u +%Y%m%d%H%MZ)
 
 .PHONY: template-name prepare build build-rootimg build-rpm
 


### PR DESCRIPTION
**Description of Changes**
This pull request aims to address reproducibility issues identified in the core-admin-client builds for Qubes OS. The key changes involve normalizing timestamps and other environment-dependent values that impacted the checksum and metadata consistency between builds.

**Modifications Made**
Environment Variable for Timestamps
Added _$SOURCE_DATE_EPOCH_ to replace direct date calls across several files:

**Files Updated**:
_plugins/build_rpm/scripts/rpmbuildinfo
plugins/installer/Makefile
plugins/template/Makefile_
**Description:**
Replaced all instances of direct date commands with $SOURCE_DATE_EPOCH to ensure the builds use a consistent timestamp. This prevents new timestamps from being generated each time the build runs.

**RPM Metadata Consistency**
Updates to RPM metadata generation scripts to ensure deterministic checksums:

**Files Updated:**
__plugins/source_rpm/scripts/generate-changelog
plugins/source_rpm/scripts/clamp-changelog-entry-dat_e_
**Description:**
These changes reset the metadata timestamps to $SOURCE_DATE_EPOCH, ensuring identical metadata across builds.
File Permission Normalization

**Files Updated:**
_plugins/build_rpm/scripts/rpmbuildinfo_
**Description:**
Standardized file permission handling within the scripts to ensure permissions are consistent between builds.

**Testing Results**
After these changes, two separate builds were created and compared using diffoscope. The results confirmed:

Identical Checksums for files in the RPM packages.
Consistent Metadata without varying timestamps or permissions across builds.

