### PR TITLE
Make setting template.conf more flexible

### DIFF
--- a/example-configs/qubes-os-main.yml
+++ b/example-configs/qubes-os-main.yml
@@ -37,12 +37,14 @@ templates:
       options:
         - minimal
         - no-recommends
+        - install-kernel
   - whonix-workstation-17:
       dist: bookworm
       flavor: whonix-workstation
       options:
         - minimal
         - no-recommends
+        - install-kernel
 
 components:
   - builder-rpm:

--- a/example-configs/qubes-os-r4.2.yml
+++ b/example-configs/qubes-os-r4.2.yml
@@ -38,12 +38,14 @@ templates:
       options:
         - minimal
         - no-recommends
+        - install-kernel
   - whonix-workstation-17:
       dist: bookworm
       flavor: whonix-workstation
       options:
         - minimal
         - no-recommends
+        - install-kernel
 
 components:
   - builder-rpm:

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -281,7 +281,7 @@ class TemplateBuilderPlugin(TemplatePlugin):
             )
         else:
             raise TemplateError("Unsupported template.")
-        template_flavor_dir = [
+        template_flavor_dir += [
             f"+{option}:{template_content_dir}/{option}"
             for option in template_options
         ]

--- a/qubesbuilder/plugins/template/scripts/qubeize-image
+++ b/qubesbuilder/plugins/template/scripts/qubeize-image
@@ -107,7 +107,7 @@ cp -r "${appmenus}" "${ARTIFACTS_DIR}/appmenus"
 echo "--> Creating template config file..."
 _conf_dir="${CONFIG_DIR:-${TEMPLATE_CONTENT_DIR}}"
 
-template_conf="$(get_file_or_directory_for_current_flavor "${_conf_dir}/template.conf")"
+template_conf="$(get_file_or_directory_for_current_flavor "template.conf")"
 if [ -z "$template_conf" ]; then
     template_conf="${PLUGINS_DIR}/template/template_generic.conf"
 fi


### PR DESCRIPTION
Specifically allow setting it separately for different flavors of the Debian
template (like Whonix templates), not only in the distribution main repo.
Previously it was possible to set template.conf for Whonix separately, but it
would need to be done in qubes-builder-debian repo, not qubes-template-whonix.

QubesOS/qubes-issues#9570