### PR TITLE
template: consider also no-flavor dir when looking for appmenus

### DIFF
--- a/qubesbuilder/plugins/template/scripts/functions.sh
+++ b/qubesbuilder/plugins/template/scripts/functions.sh
@@ -112,6 +112,8 @@ get_file_or_directory_for_current_flavor() {
             file_or_directory="${resource_dir}/${resource_without_ext}_${DIST_NAME}_${DIST_VER}_${TEMPLATE_FLAVOR}${ext}"
         elif [ -e "${resource_dir}/${resource_without_ext}_${DIST_NAME}_${TEMPLATE_FLAVOR}${ext}" ]; then
             file_or_directory="${resource_dir}/${resource_without_ext}_${DIST_NAME}_${TEMPLATE_FLAVOR}${ext}"
+        elif [ -e "${resource_dir}/${resource_without_ext}_${DIST_NAME}_${DIST_VER}${ext}" ]; then
+            file_or_directory="${resource_dir}/${resource_without_ext}_${DIST_NAME}_${DIST_VER}${ext}"
         elif [ -e "${resource_dir}/${resource_without_ext}_${DIST_NAME}${ext}" ]; then
             file_or_directory="${resource_dir}/${resource_without_ext}_${DIST_NAME}${ext}"
         elif [ -e "${resource_dir}/${resource_without_ext}${ext}" ]; then


### PR DESCRIPTION
When building a template, look for appmenus under the following names:
- appmenus_(dist-codename)_(flavor)
- appmenus_(dist-codename)
- appmenus_(dist-name)_(dist-ver)_(flavor)
- appmenus_(dist-name)_(flavor)
- appmenus_(dist-name)_(dist-ver) <- added in this commit
- appmenus_(dist-name)
- appmenus

Where `(dist-codename)` is for example `fc41`, `(dist-name)` is for
example `fedora` and `(dist-ver)` is for example `41`.

For fedora-41 template (empty flavor) it means appmenus can be placed in
`appmenus_fedora_41` directory, instead of `appmenus_fedora_41_`. And
that `appmenus_fedora_41` (instead of `appmenus_fedora`) will be used
also for Fedora 41 flavors that don't have have its own flavor-specific
directory.

Keeing `appmenus_(dist-name)_(flavor)` above version specific dir allows
keeping common `appmenus_fedora_minimal`, instead of needing to
duplicate it for each version (which would be the case if
`appmenus_(dist-name)_(dist-ver)` would be above
`appmenus_(dist-name)_(flavor)`). In other words, only-flavor-specific
dir have priority over only-version-specific dir.

QubesOS/qubes-issues#9244