### PR TITLE
template: create filesystem on EFI partition

### DIFF
--- a/dependencies-fedora-qubes-executor.txt
+++ b/dependencies-fedora-qubes-executor.txt
@@ -2,6 +2,7 @@ createrepo_c
 debootstrap
 devscripts
 dnf-plugins-core
+dosfstools
 dpkg-dev
 git
 mock

--- a/dockerfiles/fedora-mock.Dockerfile
+++ b/dockerfiles/fedora-mock.Dockerfile
@@ -15,6 +15,7 @@ RUN dnf -y update && \
         debootstrap \
         devscripts \
         dnf-plugins-core \
+        dosfstools \
         dpkg-dev \
         e2fsprogs \
         git \

--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/fedora@sha256:3ec60eb34fa1a095c0c34dd37cead9fd38afb62612d43892fcf1d3425c32bc1e
+FROM docker.io/library/fedora@sha256:3da64cb89971a1cdbc6046e307eeebcb54f7281c0a606ee48d9995473f6b88d5
 MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 
 # Install dependencies for Qubes Builder

--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -12,6 +12,7 @@ RUN dnf -y update && \
         debootstrap \
         devscripts \
         dnf-plugins-core \
+        dosfstools \
         dpkg-dev \
         e2fsprogs \
         git \

--- a/qubesbuilder/plugins/template/scripts/prepare-image
+++ b/qubesbuilder/plugins/template/scripts/prepare-image
@@ -90,6 +90,9 @@ EOF
 
         IMG_LOOP=$(/sbin/losetup -P -f --show "$IMG")
         IMG_DEV=${IMG_LOOP}p3
+
+        udevadm settle --exit-if-exists="${IMG_LOOP}p1"
+        /sbin/mkfs.vfat -S 4096 -n EFI "${IMG_LOOP}p1" || exit 1
     else
         IMG_LOOP=$(/sbin/losetup -f --show "$IMG")
         IMG_DEV=${IMG_LOOP}


### PR DESCRIPTION
Bootloader isn't installed there yet, but having the filesystem allows
systemd to mount it (it really wants to, even if not booing in EFI
mode...) instead of failing.
And also, set 4k sector size to avoid compatibility issues.

QubesOS/qubes-issues#4974
Fixes QubesOS/qubes-issues#8954