### PR TITLE
template: fix handling multiple template dirs

### DIFF
--- a/qubesbuilder/plugins/template/scripts/functions.sh
+++ b/qubesbuilder/plugins/template/scripts/functions.sh
@@ -87,7 +87,7 @@ get_file_or_directory_for_current_flavor() {
         resource_dirs=( "$(dirname "${resource}")" )
         resource="$(basename "${resource}")"
     else
-        mapfile resource_dirs <<<"$(templateDirs)"
+        mapfile -t resource_dirs <<<"$(templateDirs)"
     fi
 
     # Determine if resource has an extension. If it has,
@@ -369,7 +369,7 @@ templateFile() {
     local template_flavor="$3"
     local template_dirs
 
-    template_dirs="$(templateDirs "${template_flavor}")"
+    mapfile -t template_dirs <<<"$(templateDirs "${template_flavor}")"
 
     splitPath "${file}" path_parts
 
@@ -430,7 +430,7 @@ copyTreeExec() {
     local target_dir="$4"
     local template_dirs
 
-    template_dirs="$(templateDirs "${template_flavor}")"
+    mapfile -t template_dirs <<<"$(templateDirs "${template_flavor}")"
 
     for template_dir in "${template_dirs[@]}"; do
         local source_dir


### PR DESCRIPTION
The templateDirs function can return multiple entries. In practice,
until recently, it always returned only one, but the code pretended to
support multiple of them. Fix it to really handle multiple entries.

Specifically:

    template_dirs="$(templateDirs ...)"
    for template_dir in "${template_dirs[@]}"; do

does not work, because `template_dirs` is not set as an array. Do this
instead:

    mapfile -t template_dirs <<<"$(templateDirs ...)"

to properly split entries into array.

Fixes: 6d3cbd2 "Do not discard flavor-specific flavor dirs"

Reported by @Minimalist73 at https://github.com/QubesOS/updates-status/issues/5302#issuecomment-2528269383