### PR TITLE
Run init inside container

### DIFF
--- a/qubesbuilder/executors/container.py
+++ b/qubesbuilder/executors/container.py
@@ -219,6 +219,7 @@ class ContainerExecutor(Executor):
                     privileged=True,
                     environment=environment,
                     mounts=mounts,
+                    init=True,
                 )
 
                 # copy-in hook


### PR DESCRIPTION
Add init=True when creating a container, to have a process that reaps
processes. Otherwise the main run process (bash) is PID 1 and it doesn't
cleanup unexpected processes leading to a lot of zombies. This is
especially important for Arch's pacman, which uses GPGME, which in turns
heavily relies on PID 1 to cleanup gpg processes
(https://github.com/gpg/gpgme/blob/7a42ec5d466dfb5d4571773e22a51d0786b76d85/src/posix-io.c#L554).
PID 1 that doesn't cleanup processes leads to quickly reaching process
limit, which then causes package verification failures.

https://gitlab.archlinux.org/pacman/pacman/-/issues/177
https://github.com/QubesOS/qubes-issues/issues/9193