### PR TITLE
Fix init-cache for Debian

### DIFF
--- a/qubesbuilder/plugins/chroot_deb/__init__.py
+++ b/qubesbuilder/plugins/chroot_deb/__init__.py
@@ -132,7 +132,7 @@ class DEBChrootPlugin(DEBDistributionPlugin, ChrootPlugin):
                 )
             ]
             cmd = [
-                f"sed -i '#/tmp/qubes-deb#d' {executor.get_plugins_dir()}/chroot_deb/pbuilder/pbuilderrc",
+                f"sed -i '/qubes-deb/d' {executor.get_plugins_dir()}/chroot_deb/pbuilder/pbuilderrc",
                 f"mkdir -p {executor.get_cache_dir()}/aptcache",
             ]
             pbuilder_cmd = [


### PR DESCRIPTION
Create /build/repository in case it does not already exist.  This is needed by pbuilder, which bind-mounts the directory.

Also use proper shell quoting in more places.