### PR TITLE
qb: Always run qubesbuilder-cli from the repo directory

### DIFF
--- a/qb
+++ b/qb
@@ -1,1 +1,3 @@
-qubesbuilder-cli
+#!/bin/sh --
+case $0 in (/*) cd "${0%/*}/";; (*/*) cd "./${0%/*}";; esac
+exec ./qubesbuilder-cli "$@"


### PR DESCRIPTION
Running qubesbuilder-cli from the repository directory is nearly always the desired behavior, so have the 'qb' convenience script do it automatically.