### PR TITLE
publish_rpm: use createrepo --update

### DIFF
--- a/qubesbuilder/plugins/publish_rpm/__init__.py
+++ b/qubesbuilder/plugins/publish_rpm/__init__.py
@@ -102,9 +102,9 @@ class RPMPublishPlugin(RPMDistributionPlugin, PublishPlugin):
             self.config.sources_dir
             / f"qubes-release/comps/comps-{self.dist.package_set}.xml"
         ).exists():
-            cmd.append("createrepo_c -g comps.xml .")
+            cmd.append("createrepo_c --update -g comps.xml .")
         else:
-            cmd.append("createrepo_c .")
+            cmd.append("createrepo_c --update .")
         try:
             shutil.rmtree(target_dir / "repodata")
             executor.run(cmd)


### PR DESCRIPTION
Reuse existing repo metadata for unchanged packages. This should
significantly speed up pushing packages from current-testing to current
(and also pushing them to the current-testing in the first place).
Before this change, publishing rpm packages was several times slower
than deb packages...