### PR TITLE
Remove Windows tools from example configs

### DIFF
--- a/example-configs/qubes-os-main.yml
+++ b/example-configs/qubes-os-main.yml
@@ -176,8 +176,6 @@ components:
   - antievilmaid
   - xscreensaver
   - remote-support
-  - windows-tools-cross
-
 
 #executor:
 #  type: docker

--- a/example-configs/qubes-os-r4.2.yml
+++ b/example-configs/qubes-os-r4.2.yml
@@ -183,7 +183,6 @@ components:
   - xscreensaver
   - remote-support
   - openssh
-  - windows-tools-cross
 
 
 #executor:

--- a/example-configs/qubes-os-r4.3.yml
+++ b/example-configs/qubes-os-r4.3.yml
@@ -172,7 +172,6 @@ components:
   - antievilmaid
   - xscreensaver
   - remote-support
-  - windows-tools-cross
 
 
 #executor:


### PR DESCRIPTION
The current Windows tools are a dummy package, and the future, the Windows tools will be built on Windows itself.