### PR TITLE
Fix data type issue

### DIFF
--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -228,7 +228,7 @@ class TemplateBuilderPlugin(TemplatePlugin):
                     f"+whonix-gateway:{executor.get_sources_dir()}/template-whonix",
                     f"+whonix-workstation:{executor.get_sources_dir()}/template-whonix",
                 ]
-            if self.template.flavor in ("kicksecure-17"):
+            if self.template.flavor in ("kicksecure-17",):
                 self.dependencies += [
                     ComponentDependency("template-kicksecure")
                 ]


### PR DESCRIPTION
I missed *one comma* in my earlier pull request for adding a Kicksecure template, so what should have been a one-item tuple got treated as a string. This bug is specifically in the line `if self.template.flavor in ("kicksecure-17"):` - if `self.template.flavor` is anything that is "in" the string "kicksecure-17", it will cause the Kicksecure code path to be followed incorrectly. Most notably `"" in ("kicksecure-17")` will resolve to True, i.e. an empty string will trigger this. To fix the bug, add a comma just after the `"kicksecure-17"` bit so that Python can figure out this is a tuple and not a string.