### PR TITLE
Fix Kicksecure template flavor name

### DIFF
--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -232,7 +232,7 @@ class TemplateBuilderPlugin(TemplatePlugin):
                     f"+whonix-gateway:{self.executor.get_sources_dir()}/template-whonix",
                     f"+whonix-workstation:{self.executor.get_sources_dir()}/template-whonix",
                 ]
-            if self.template.flavor in ("kicksecure-17",):
+            if self.template.flavor in ("kicksecure",):
                 self.dependencies += [
                     ComponentDependency("template-kicksecure")
                 ]


### PR DESCRIPTION
https://github.com/QubesOS/qubes-builderv2/pull/178 broke Kicksecure template builds, as I learned after several hours of debugging. `-17` is not part of the flavor name. This didn't show up before because of the missing comma that was fixed in https://github.com/QubesOS/qubes-builderv2/pull/178, but adding it made this issue apparent.

I have a working template build after applying the change from this PR.