### PR TITLE
archlinux: reduce builder chroot ParallelDownloads to 1

### DIFF
--- a/qubesbuilder/plugins/chroot_archlinux/conf/pacman.conf.j2
+++ b/qubesbuilder/plugins/chroot_archlinux/conf/pacman.conf.j2
@@ -34,7 +34,7 @@ Architecture = auto
 #NoProgressBar
 #CheckSpace
 #VerbosePkgLists
-ParallelDownloads = 5
+ParallelDownloads = 1
 
 [core]
 SigLevel = Required DatabaseOptional


### PR DESCRIPTION
When pointing the builder to a local apt-cacher-ng instance, build often fails during package installation due to HTTP 503.

apt-cacher-ng is primarly intended for package managers not doing any parallelisation of downloads (like apt).

Reducing pacman ParallelDownloads to 1 should improve robustness and is in any case kinder to the mirror.