### PR TITLE
archlinux: fix: NO_PROXY=127.0.0.1

### DIFF
--- a/qubesbuilder/plugins/build_archlinux/scripts/update-local-repo.sh
+++ b/qubesbuilder/plugins/build_archlinux/scripts/update-local-repo.sh
@@ -49,8 +49,8 @@ chroot_cmd sed "s/^ *CheckSpace/#CheckSpace/g" -i /etc/pacman.conf
 
 # Update archlinux keyring first so that Archlinux can be updated even after a long time
 chroot_cmd /bin/sh -c \
-    "http_proxy='${REPO_PROXY}' pacman -Sy --noconfirm --noprogressbar archlinux-keyring"
+    "no_proxy='${NO_PROXY:-127.0.0.1}' http_proxy='${REPO_PROXY}' pacman -Sy --noconfirm --noprogressbar archlinux-keyring"
 
 # Now update system
 chroot_cmd /bin/sh -c \
-    "http_proxy='${REPO_PROXY}' pacman -Syu --noconfirm --noprogressbar"
+    "no_proxy='${NO_PROXY:-127.0.0.1}' http_proxy='${REPO_PROXY}' pacman -Syu --noconfirm --noprogressbar"


### PR DESCRIPTION
otherwise requests to repos on localhost will be passed via the proxy, which we generally don't want.

Related:
- https://github.com/QubesOS/qubes-builder-archlinux/pull/76
- https://github.com/QubesOS/qubes-core-agent-linux/pull/564