### PR TITLE
fix: skip rsyncing mtime/ctime for dirs and symlinks

### DIFF
--- a/qubesbuilder/plugins/installer/__init__.py
+++ b/qubesbuilder/plugins/installer/__init__.py
@@ -746,7 +746,7 @@ class InstallerPlugin(DistributionPlugin):
 
             try:
                 cmd = [
-                    f"rsync --partial --progress --hard-links -air --mkpath -- {iso_dir}/ {remote_path}"
+                    f"rsync --partial --progress --hard-links -OJair --mkpath -- {iso_dir}/ {remote_path}"
                 ]
                 self.executor.run(cmd)
             except ExecutorError as e:

--- a/qubesbuilder/plugins/template/__init__.py
+++ b/qubesbuilder/plugins/template/__init__.py
@@ -897,7 +897,7 @@ class TemplateBuilderPlugin(TemplatePlugin):
 
                 for relative_dir in directories_to_upload:
                     cmd = [
-                        f"rsync --partial --progress --hard-links -air --mkpath -- {local_path / relative_dir}/ {remote_path}/{relative_dir}/"
+                        f"rsync --partial --progress --hard-links -OJair --mkpath -- {local_path / relative_dir}/ {remote_path}/{relative_dir}/"
                     ]
                     self.executor.run(cmd)
             except ExecutorError as e:

--- a/qubesbuilder/plugins/upload/__init__.py
+++ b/qubesbuilder/plugins/upload/__init__.py
@@ -106,7 +106,7 @@ class UploadPlugin(DistributionPlugin):
 
             for relative_dir in directories_to_upload:
                 cmd = [
-                    f"rsync --partial --progress --hard-links -air --mkpath -- {local_path / relative_dir}/ {remote_path}/{relative_dir}/"
+                    f"rsync --partial --progress --hard-links -OJair --mkpath -- {local_path / relative_dir}/ {remote_path}/{relative_dir}/"
                 ]
                 self.executor.run(cmd)
         except ExecutorError as e:


### PR DESCRIPTION
Works around file system incompatibilities and skip unnecessary IO by adding `-OJ` flags to rsync invocations.

From rsync manpage:
```
       --omit-dir-times, -O     omit directories from --times
       --omit-link-times, -J    omit symlinks from --times
```

(Should we omit rsyncing ctimes - and perhaps even mtimes - alltogether even for files? Seems unnecessary and if builds depend on them that seems like something that should be addressed to make builds more reproducible? Can see the case for keeping mtime for uploaded artifacts, though)

