### PR TITLE
fix: handle create uncompressed .tar archive from git sources

### DIFF
--- a/qubesbuilder/plugins/fetch/scripts/create-archive
+++ b/qubesbuilder/plugins/fetch/scripts/create-archive
@@ -83,6 +83,8 @@ else
 fi
 
 case "$GIT_ARCHIVE_TYPE" in
+    "tar") mv -f "${GIT_TARBALL_NAME}" "${GIT_TARBALL_NAME}.${GIT_ARCHIVE_TYPE}" 
+        ;;
     "gz") gzip -fn "${GIT_TARBALL_NAME}"
         ;;
     "bz2") bzip2 -f "${GIT_TARBALL_NAME}"


### PR DESCRIPTION
This PR correctly handles the creation of uncompressed .tar archives when the `uncompress=True` argument is specified in .qubesbuilder for git sources. For example, the qubes-linux-kernel requires the kernel source code to be provided in an uncompressed .tar file.