### PR TITLE
Revert "arch: workaround "GPGME error: Inappropriate ioctl for device" issue"

### DIFF
--- a/qubesbuilder/plugins/build_archlinux/__init__.py
+++ b/qubesbuilder/plugins/build_archlinux/__init__.py
@@ -369,8 +369,6 @@ class ArchlinuxBuildPlugin(ArchlinuxDistributionPlugin, BuildPlugin):
                 f"-d {self.executor.get_repository_dir()}:/builder/repository -- ",
                 f"--syncdeps --noconfirm --skipinteg",
             ]
-            # make stdout a pipe instead of pts, to not confuse gpgme
-            build_command += ["| cat"]
 
             cmd += [f"cd {source_dir}", " ".join(build_command)]
 

--- a/qubesbuilder/plugins/chroot_archlinux/__init__.py
+++ b/qubesbuilder/plugins/chroot_archlinux/__init__.py
@@ -80,7 +80,7 @@ def get_archchroot_cmd(
         "sudo pacman-key --init",
         "sudo pacman-key --populate",
         f"sudo mkdir -p {chroot_dir.parent}",
-        " ".join(mkarchchroot_cmd) + " | cat",
+        " ".join(mkarchchroot_cmd),
     ]
 
     return cmd


### PR DESCRIPTION
The actual issue got fixed in d8d0d68 "Run init inside container",
revert the workaround.

This reverts commit 8e219c9343f2d1c4d5cceb2b942e44c258f6c92b.