### PR TITLE
fix: qualify dockerfile base image prefixes

### DIFF
--- a/dockerfiles/debian.Dockerfile
+++ b/dockerfiles/debian.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian@sha256:e83913597ca9deb9d699316a9a9d806c2a87ed61195ac66ae0a8ac55089a84b9
+FROM docker.io/library/debian@sha256:e83913597ca9deb9d699316a9a9d806c2a87ed61195ac66ae0a8ac55089a84b9
 MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/fedora.Dockerfile
+++ b/dockerfiles/fedora.Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora@sha256:3ec60eb34fa1a095c0c34dd37cead9fd38afb62612d43892fcf1d3425c32bc1e
+FROM docker.io/library/fedora@sha256:3ec60eb34fa1a095c0c34dd37cead9fd38afb62612d43892fcf1d3425c32bc1e
 MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 
 # Install dependencies for Qubes Builder

--- a/dockerfiles/ubuntu.Dockerfile
+++ b/dockerfiles/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu@sha256:6e75a10070b0fcb0bead763c5118a369bc7cc30dfc1b0749c491bbb21f15c3c7
+FROM docker.io/library/ubuntu@sha256:6e75a10070b0fcb0bead763c5118a369bc7cc30dfc1b0749c491bbb21f15c3c7
 MAINTAINER Frédéric Pierret <frederic@invisiblethingslab.com>
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Resolves https://github.com/QubesOS/qubes-issues/issues/9966

Separately, perhaps about time to bump the base image hashes (should make for more efficient builds due to minimizing initial upgrade delta)