### PR TITLE
example-configs/archlinux: remove non-existing pkgs bin86,dev86

### DIFF
--- a/example-configs/archlinux.yml
+++ b/example-configs/archlinux.yml
@@ -11,12 +11,10 @@ qubes-release: r4.2
 cache:
   vm-archlinux:
     packages:
-      - bin86
       - bridge-utils
       - conntrack-tools
       - dconf
       - desktop-file-utils
-      - dev86
       - fakeroot
       - gawk
       - gcc


### PR DESCRIPTION
`init-cache` fails for archlinux example due to missing packages `bin86`,`dev86`. Fix.