### PR TITLE
windows: fix local build

### DIFF
--- a/qubesbuilder/plugins/build_windows/scripts/build-sln.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/build-sln.ps1
@@ -69,6 +69,11 @@ $ewdk_lib_dir = "$env:EWDK_PATH\Program Files\Windows Kits\10\Lib\$ewdk_version"
 $ewdk_lib = "$ewdk_lib_dir\um\$arch;$ewdk_lib_dir\ucrt\$arch"
 
 $env:WindowsSDK_IncludePath = $ewdk_inc
+
+# Paths for native executables
+$env:EWDK_INCLUDES="$env:EWDK_PATH\Program Files\Windows Kits\10\Include\$env:Version_Number\km"
+$env:EWDK_LIBS="$env:EWDK_PATH\Program Files\Windows Kits\10\Lib\$env:Version_Number\um\x64"
+
 Set-Item -Path "env:WindowsSDK_LibraryPath_$arch" -Value $ewdk_lib
 $env:PATH += ";$env:EWDK_PATH\Program Files\Windows Kits\10\bin\$ewdk_version\$arch"
 
@@ -88,7 +93,7 @@ if ($testsign) {
 
 # Iterate over builder's local repository to collect dependencies
 if (! (Test-Path $repo -PathType Container)) {
-    LogError "Invalid repository directory: $repo"
+    New-Item -Path $repo -ItemType Directory -Force
 }
 
 $env:QUBES_REPO = Resolve-Path $repo
@@ -111,8 +116,11 @@ foreach ($dep in Get-ChildItem -Path $repo) {
     }
 }
 
+$env:QB_SCRIPTS = "$PSScriptRoot"
+
 LogDebug "QUBES_INCLUDES = $env:QUBES_INCLUDES"
 LogDebug "QUBES_LIBS = $env:QUBES_LIBS"
+LogDebug "QUBES_REPO = $env:QUBES_REPO"
 
 if ($distfiles -ne "") {
     if (! (Test-Path $distfiles -PathType Container)) {

--- a/qubesbuilder/plugins/build_windows/scripts/common.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/common.ps1
@@ -25,9 +25,7 @@ function Launch-EWDK {
         $kv = $line.split("=")
         $var_name = $kv[0]
         $var_value = $kv[1]
-        if (! (Test-Path -Path "env:$var_name")) {
-            Set-Item -Path "env:$var_name" -Value $var_value
-        }
+        Set-Item -Path "env:$var_name" -Value $var_value
     }
 }
 

--- a/qubesbuilder/plugins/build_windows/scripts/local/build.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/local/build.ps1
@@ -14,69 +14,23 @@ if (! (Test-Path $dir -PathType Container)) {
 
 $dir = Resolve-Path $dir
 
-$script_dir = Resolve-Path "$PSScriptRoot\.."
+. "$PSScriptRoot\..\common.ps1"
+$env:EWDK_PATH = Find-EWDK
+Launch-EWDK
 
-# create local repo, without version since it's stripped by the build script anyway
-$component = Split-Path $dir -Leaf
-$repo_component = $component.TrimStart("qubes-") # normalize name
-$repo_dir = "$repo\$repo_component"
-if (Test-Path $repo_dir) {
-    Remove-Item -Path $repo_dir -Recurse -Force
-}
-New-Item -Path $repo_dir -ItemType Directory -Force
-
-$component_version = (Get-Content "$dir\version").Trim()
-
-function ReplacePlaceholders {
-    param([string]$str)
-    return $str.Replace("@CONFIGURATION@", $cfg).Replace("@VERSION@", $component_version)
-}
+$env:QB_LOCAL = 1
+$env:QUBES_REPO = $repo
 
 Import-Module powershell-yaml
-
 $yaml = ConvertFrom-Yaml (Get-Content "$dir\.qubesbuilder" -Raw)
-
-# download distfiles
-if ($yaml.ContainsKey('source') -and $yaml['source'].ContainsKey('files')) {
-    # for local builds, keep distfiles in the source dir for easy access by the component
-    $distfiles = "$dir\.distfiles"
-    New-Item -Path $distfiles -ItemType Directory -Force
-
-    foreach ($entry in $yaml['source']['files']) {
-        $url = $entry['url']
-        $file = Split-Path $url -Leaf
-        $out_path = "$distfiles\$file"
-        $hash_file = $entry['sha256']
-        $expected = (Get-Content "$dir\$hash_file").Trim()
-
-        if (! (Test-Path $out_path)) {
-            Invoke-WebRequest $url -OutFile $out_path
-        }
-
-        $hash = (Get-FileHash $out_path -Algorithm SHA256).Hash
-        if ($hash -ne $expected) {
-            Remove-Item $out_path
-            Write-Error "Invalid sha256 for downloaded '$file', aborting: got $hash, expected $expected"
-        }
-    }
-}
 
 # TODO: make this more generic
 $root = $yaml['vm']['windows']
 
-. "$script_dir\common.ps1"
-
-# need our own EWDK environment for signing
-$env:EWDK_PATH = Find-EWDK
-Launch-EWDK
-
-# generate testsign cert
-& "$script_dir\local\create-cert.ps1" "$dir\sign.crt"
-
 foreach ($target in $root['build']) {
     # build
     $args = @(
-        "$script_dir\build-sln.ps1",
+        "$PSScriptRoot\..\build-sln.ps1",
         "-solution", "$dir\$target",
         "-configuration", $cfg,
         "-repo", $repo,
@@ -84,47 +38,10 @@ foreach ($target in $root['build']) {
         "-noisy"
     )
 
-    if ($distfiles -ne $null) {
-        $args += @("-distfiles", $distfiles)
+    if (Test-Path "$dir\.distfiles") {
+        $args += @("-distfiles", "$dir\.distfiles")
     }
 
     $proc = Start-Process -NoNewWindow -PassThru powershell -ArgumentList $args
     $proc.WaitForExit()
-
-    # copy artifacts to local repo
-    $kinds = @('bin', 'inc', 'lib')
-    foreach ($kind in $kinds) {
-        New-Item -Path "$repo_dir\$kind" -ItemType Directory -Force
-        foreach ($output in $root[$kind]) {
-            # TODO: make this more generic
-            $output = ReplacePlaceholders $output
-
-            if ($kind -eq "bin") {
-                # sign if needed
-                $do_sign = $false
-                @(".exe", ".dll", ".sys", ".cat") | % { $do_sign = $do_sign -or $output.EndsWith($_) }
-
-                if ($do_sign) {
-                    foreach ($skip in $root['skip-test-sign']) {
-                        $skip = ReplacePlaceholders $skip
-                        if ($output -eq $skip) {
-                            $do_sign = $false
-                            break
-                        }
-                    }
-
-                    if ($do_sign) {
-                        & "$script_dir\local\sign.ps1" "$dir\sign.crt" "$dir\$output"
-                    }
-                }
-            }
-
-            Copy-Item "$dir\$output" "$repo_dir\$kind"
-        }
-    }
-
-    # copy testsign cert to local repo
-    Copy-Item "$dir\sign.crt" $repo_dir
-    # delete testsign cert from OS store
-    & "$script_dir\local\delete-cert.ps1" "$dir\sign.crt"
 }

--- a/qubesbuilder/plugins/build_windows/scripts/local/create-cert.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/local/create-cert.ps1
@@ -7,6 +7,7 @@ $cert_path = $args[0]
 $cn = "Qubes Tools"
 $end_date = (Get-Date).AddYears(5)
 
+echo "Creating code signing certificate..."
 $cert = New-SelfSignedCertificate -KeyUsage DigitalSignature -KeySpec Signature -Type CodeSigningCert -HashAlgorithm sha256 -CertStoreLocation "Cert:\CurrentUser\My" -Subject $cn -NotAfter $end_date
 
 Export-Certificate -Cert $cert -FilePath $cert_path

--- a/qubesbuilder/plugins/build_windows/scripts/local/delete-cert.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/local/delete-cert.ps1
@@ -13,6 +13,7 @@ if (! (Test-Path $cert_path)) {
     exit 0
 }
 
+echo "Deleting code signing certificate..."
 $tp = (Get-PfxCertificate -FilePath $cert_path).Thumbprint
 
 Remove-Item $cert_path

--- a/qubesbuilder/plugins/build_windows/scripts/local/functions.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/local/functions.ps1
@@ -1,0 +1,155 @@
+# Get component-local directory for output artifacts.
+function QB-Get-LocalComponentRepo {
+    param (
+        [string]$component_src_dir
+    )
+
+    return "$component_src_dir\.artifacts"
+}
+
+# Create component-specific output artifacts repository.
+# Returns path to the component repository.
+function QB-Create-LocalComponentRepo {
+    param (
+        [string]$component_src_dir, # this component source directory
+        [string]$repo_root # root repo directory for all components
+    )
+
+    # create component-local repo dir
+    $component_repo_dir = QB-Get-LocalComponentRepo $component_src_dir
+    if (Test-Path $component_repo_dir) {
+        Remove-Item -Path $component_repo_dir -Recurse -Force
+    }
+    New-Item -Path $component_repo_dir -ItemType Directory -Force
+
+    # create link in the root repo, without version
+    $component = Split-Path $component_src_dir -Leaf
+    $repo_component = $component.TrimStart("qubes-") # normalize name
+    $repo_entry = "$repo_root\$repo_component" # link name
+    New-Item -Path $repo_entry -ItemType SymbolicLink -Value $component_repo_dir -Force
+    return $component_repo_dir
+}
+
+# Perform required pre-build actions (download prerequisites, create test sign cert).
+function QB-LocalPreBuild {
+    param (
+        [string]$component_src_dir, # this component source directory
+        [string]$repo_root # root repo directory for all components
+    )
+
+    if (! (Test-Path -Path env:QB_LOCAL)) {
+        # we're being built via the proper builder, it does its own pre/post build processing
+        return
+    }
+
+    QB-Create-LocalComponentRepo $component_src_dir $repo_root
+
+    Import-Module powershell-yaml 2>&1 | Out-Null
+    $yaml = ConvertFrom-Yaml (Get-Content "$component_src_dir\.qubesbuilder" -Raw)
+
+    # download distfiles
+    if ($yaml.ContainsKey('source') -and $yaml['source'].ContainsKey('files')) {
+        echo "Downloading prerequisites..."
+        # for local builds, keep distfiles in the source dir for easy access by the component
+        $distfiles = "$component_src_dir\.distfiles"
+        New-Item -Path $distfiles -ItemType Directory -Force
+
+        foreach ($entry in $yaml['source']['files']) {
+            $url = $entry['url']
+            $file = Split-Path $url -Leaf
+            $out_path = "$distfiles\$file"
+            $hash_file = $entry['sha256']
+            $expected = (Get-Content "$component_src_dir\$hash_file").Trim()
+
+            if (! (Test-Path $out_path)) {
+                Invoke-WebRequest $url -OutFile $out_path
+            }
+
+            $hash = (Get-FileHash $out_path -Algorithm SHA256).Hash
+            if ($hash -ne $expected) {
+                Remove-Item $out_path
+                Write-Error "[!] Invalid sha256 for downloaded '$file', aborting: got $hash, expected $expected"
+            }
+        }
+    }
+
+    # generate testsign cert
+    & "$PSScriptRoot\create-cert.ps1" "$component_src_dir\sign.crt"
+}
+
+function QB-Replace-LocalPlaceholders {
+    param (
+        [string]$str,
+        [string]$cfg, # build configuration
+        [string]$ver # component version
+    )
+    return $str.Replace("@CONFIGURATION@", $cfg).Replace("@VERSION@", $ver)
+}
+
+function QB-LocalPostBuild {
+    param (
+        [string]$component_src_dir, # this component source directory
+        [string]$repo_root, # root repo directory for all components
+        [string]$build_configuration # Release/Debug
+    )
+
+    if (! (Test-Path -Path env:QB_LOCAL)) {
+        # we're being built via the proper builder, it does its own pre/post build processing
+        return
+    }
+
+    # EWDK is needed for signing
+    if (! (Test-Path -Path env:EnterpriseWDK)) {
+        . "$PSScriptRoot\..\common.ps1"
+        $env:EWDK_PATH = Find-EWDK
+        Launch-EWDK
+    }
+
+    $component_version = (Get-Content "$component_src_dir\version").Trim()
+
+    # copy output artifacts to local repo
+    $repo_dir = QB-Get-LocalComponentRepo $component_src_dir
+
+    Import-Module powershell-yaml 2>&1 | Out-Null
+    $yaml = ConvertFrom-Yaml (Get-Content "$component_src_dir\.qubesbuilder" -Raw)
+    # TODO: make this more generic
+    $root = $yaml['vm']['windows']
+
+    $kinds = @('bin', 'inc', 'lib')
+    foreach ($kind in $kinds) {
+        echo "Signing/copying build output..."
+        New-Item -Path "$repo_dir\$kind" -ItemType Directory -Force
+        foreach ($output in $root[$kind]) {
+            # TODO: make this more generic
+            $output = QB-Replace-LocalPlaceholders $output $build_configuration $component_version
+
+            if ($kind -eq "bin") {
+                # sign if needed
+                $do_sign = $false
+                @(".exe", ".dll", ".sys", ".cat") | % { $do_sign = $do_sign -or $output.EndsWith($_) }
+
+                if ($do_sign) {
+                    foreach ($skip in $root['skip-test-sign']) {
+                        $skip = QB-Replace-LocalPlaceholders $skip $build_configuration $component_version
+                        if ($output -eq $skip) {
+                            $do_sign = $false
+                            break
+                        }
+                    }
+
+                    if ($do_sign) {
+                        & "$PSScriptRoot\sign.ps1" "$component_src_dir\sign.crt" "$component_src_dir\$output"
+                    }
+                }
+            }
+
+            Copy-Item "$component_src_dir\$output" "$repo_dir\$kind"
+        }
+    }
+
+    # copy testsign cert to local repo
+    Copy-Item "$component_src_dir\sign.crt" $repo_dir
+
+    # delete testsign cert from OS store
+    & "$PSScriptRoot\delete-cert.ps1" "$component_src_dir\sign.crt"
+}

--- a/qubesbuilder/plugins/build_windows/scripts/local/postbuild.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/local/postbuild.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$component_src_dir, # component source directory
+    [string]$repo_root, # root repo directory for all components
+    [string]$build_configuration # Debug/Release
+)
+
+# Skip if running from Qubes Builder
+if (! (Test-Path -Path env:QB_LOCAL)) {
+    exit 0
+}
+
+. $PSScriptRoot\functions.ps1
+
+QB-LocalPostBuild $component_src_dir $repo_root $build_configuration

--- a/qubesbuilder/plugins/build_windows/scripts/local/prebuild.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/local/prebuild.ps1
@@ -1,0 +1,13 @@
+param (
+    [string]$component_src_dir, # component source directory
+    [string]$repo_root # root repo directory for all components
+)
+
+# Skip if running from Qubes Builder
+if (! (Test-Path -Path env:QB_LOCAL)) {
+    exit 0
+}
+
+. $PSScriptRoot\functions.ps1
+
+QB-LocalPreBuild $component_src_dir $repo_root

--- a/qubesbuilder/plugins/build_windows/scripts/local/sign.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/local/sign.ps1
@@ -1,5 +1,9 @@
+param(
+    [string]$cert, # public cert
+    [string]$binary # binary to sign
+)
+
 # Sign the target.
-# Usage: $0 <public cert> <target>
 # The corresponding private key must reside in the OS certificate store.
 # THIS SCRIPT IS MEANT TO BE USED ONLY FOR LOCAL TEST BUILDS.
 
@@ -8,26 +12,26 @@ $ErrorActionPreference = 'Stop'
 $ts_url = "http://timestamp.digicert.com"
 
 if ($env:EWDK_PATH -eq $null) {
-    Write-Error "EWDK_PATH variable not set"
+    Write-Error "[!] EWDK_PATH variable not set"
 }
 
-if ($env:Version_Number -eq $null) {
-    Write-Error "EWDK environment not initialized"
+if ($env:EnterpriseWDK -eq $null) {
+    Write-Error "[!] EWDK environment not initialized"
 }
 
 $signtool = "$env:EWDK_PATH\Program Files\Windows Kits\10\bin\$env:Version_Number\x64\signtool.exe"
 if (! (Test-Path $signtool)) {
-    Write-Error "$signtool not found"
+    Write-Error "[!] $signtool not found"
     break
 }
 
-$cert_path = $args[0]
+$cert_path = Resolve-Path $cert
 if (! (Test-Path $cert_path)) {
-    Write-Error "$cert_path not found"
+    Write-Error "[!] $cert_path not found"
     exit 1
 }
 $sha1 = (Get-FileHash $cert_path -Algorithm SHA1).Hash
 
-$target = $args[1]
+$target = Resolve-Path $binary
 
 Start-Process -FilePath $signtool -Wait -NoNewWindow -ArgumentList "sign /sha1 $sha1 /fd sha256 /td sha256 /tr $ts_url $target"

--- a/qubesbuilder/plugins/build_windows/scripts/set-version.ps1
+++ b/qubesbuilder/plugins/build_windows/scripts/set-version.ps1
@@ -1,0 +1,18 @@
+function QB-GenerateVersionHeader {
+    param(
+        [Parameter(Mandatory)] [string]$in,
+        [Parameter(Mandatory)] [string]$out
+    )
+    $version = Get-Content $in
+    # qubes version has 3 parts, windows needs 4
+    $version += ".0"
+    $version_str = "`"" + $version + "`""
+    $version = %{$version -replace "\.", ","}
+    $hdr = "#define QWT_FILEVERSION " + $version + "`n"
+    $hdr += "#define QWT_FILEVERSION_STR " + $version_str + "`n"
+    $hdr += "#define QWT_PRODUCTVERSION QWT_FILEVERSION`n"
+    $hdr += "#define QWT_PRODUCTVERSION_STR QWT_FILEVERSION_STR`n"
+    Set-Content -Path $out $hdr
+}
+
+QB-GenerateVersionHeader $args[0] $args[1]


### PR DESCRIPTION
- Fix scripts for local command line and VS builds.
- Move the `set-version` script out of all components and make it shared via the builder.
- Keep local pre/post-build scripts in one place and make them work similar to QB build (prebuild generates testsign cert and downloads distfiles, postbuild signs executables and copies output to common repository). This makes command-line and VS builds share most of the code.
