### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/qubesbuilder/cli/cli_base.py
+++ b/qubesbuilder/cli/cli_base.py
@@ -89,7 +89,10 @@ class AliasedGroup(click.Group):
             raise click.Abort()
 
     def __call__(self, *args, **kwargs):
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
 
         def _handle_interrupt():
             # Cancel all running tasks on SIGINT

--- a/qubesbuilder/executors/__init__.py
+++ b/qubesbuilder/executors/__init__.py
@@ -176,7 +176,10 @@ class Executor(ABC):
         return rc, results[0], results[1]
 
     def execute(self, cmd, collect=False, stdin=b"", echo=True, **kwargs):
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
 
         rc, stdout, stderr = loop.run_until_complete(
             self._stream_subprocess(


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

resolves: https://github.com/QubesOS/qubes-issues/issues/10188