### PR TITLE
Quick band-aid for builderv2-github compat

### DIFF
--- a/qubesbuilder/cli/cli_installer.py
+++ b/qubesbuilder/cli/cli_installer.py
@@ -29,8 +29,12 @@ def _installer_stage(
     """
     click.echo(f"Running installer stage: {stage_name}")
 
-    ctx = click.get_current_context()
-    root_group = ctx.find_root().command
+    try:
+        ctx = click.get_current_context()
+    except RuntimeError:
+        root_group = None
+    else:
+        root_group = ctx.find_root().command
 
     host_distributions = [
         d for d in config.get_distributions() if d.package_set == "host"
@@ -43,8 +47,10 @@ def _installer_stage(
     installer_plugin = InstallerPlugin(
         dist=dist, config=config, stage=stage_name, templates=templates or []
     )
-    if hasattr(installer_plugin, "executor") and hasattr(
-        installer_plugin.executor, "cleanup"
+    if (
+        hasattr(installer_plugin, "executor")
+        and hasattr(installer_plugin.executor, "cleanup")
+        and root_group
     ):
         root_group.add_cleanup(installer_plugin.executor.cleanup)
     installer_plugin.run(

--- a/qubesbuilder/cli/cli_package.py
+++ b/qubesbuilder/cli/cli_package.py
@@ -30,8 +30,12 @@ def _component_stage(
     """
     QubesBuilderLogger.info(f"Running stages: {', '.join(stages)}")
 
-    ctx = click.get_current_context()
-    root_group = ctx.find_root().command
+    try:
+        ctx = click.get_current_context()
+    except RuntimeError:
+        root_group = None
+    else:
+        root_group = ctx.find_root().command
 
     for job in config.get_jobs(
         components=components,
@@ -39,7 +43,11 @@ def _component_stage(
         templates=[],
         stages=stages,
     ):
-        if hasattr(job, "executor") and hasattr(job.executor, "cleanup"):
+        if (
+            hasattr(job, "executor")
+            and hasattr(job.executor, "cleanup")
+            and root_group
+        ):
             root_group.add_cleanup(job.executor.cleanup)
         job.run(**kwargs)
 

--- a/qubesbuilder/cli/cli_template.py
+++ b/qubesbuilder/cli/cli_template.py
@@ -26,15 +26,23 @@ def _template_stage(
     """
     click.echo(f"Running template stages: {', '.join(stages)}")
 
-    ctx = click.get_current_context()
-    root_group = ctx.find_root().command
+    try:
+        ctx = click.get_current_context()
+    except RuntimeError:
+        root_group = None
+    else:
+        root_group = ctx.find_root().command
 
     # Qubes templates
     jobs = config.get_jobs(
         templates=templates, components=[], distributions=[], stages=stages
     )
     for job in jobs:
-        if hasattr(job, "executor") and hasattr(job.executor, "cleanup"):
+        if (
+            hasattr(job, "executor")
+            and hasattr(job.executor, "cleanup")
+            and root_group
+        ):
             root_group.add_cleanup(job.executor.cleanup)
         job.run(template_timestamp=template_timestamp)
 


### PR DESCRIPTION
builderv2-github doesn't use click, but it does call `_*_stage` functions.
Apply quick fix for now, but it needs a proper solution.

QubesOS/qubes-issues#10233