### PR TITLE
windows: fix rpc service copying

### DIFF
--- a/qubesbuilder/executors/qubes.py
+++ b/qubesbuilder/executors/qubes.py
@@ -432,10 +432,12 @@ class WindowsQubesExecutor(BaseWindowsExecutor, QubesExecutor):
             )
 
             prep_cmd = [
-                f'move /y "{inc_dir}\\qubesbuilder.WinFileCopyIn" "%QUBES_TOOLS%\\qubes-rpc\\"',
-                f'move /y "{inc_dir}\\qubesbuilder.WinFileCopyOut" "%QUBES_TOOLS%\\qubes-rpc\\"',
-                f'move /y "{inc_dir}\\qubesbuilder-file-copy-in.ps1" "%QUBES_TOOLS%\\qubes-rpc-services\\"',
-                f'move /y "{inc_dir}\\qubesbuilder-file-copy-out.ps1" "%QUBES_TOOLS%\\qubes-rpc-services\\"',
+                f"if not exist q:\\qubes-rpc mkdir q:\\qubes-rpc",
+                f"if not exist q:\\qubes-rpc-services mkdir q:\\qubes-rpc-services",
+                f'move /y "{inc_dir}\\qubesbuilder.WinFileCopyIn" "q:\\qubes-rpc\\"',
+                f'move /y "{inc_dir}\\qubesbuilder.WinFileCopyOut" "q:\\qubes-rpc\\"',
+                f'move /y "{inc_dir}\\qubesbuilder-file-copy-in.ps1" "q:\\qubes-rpc-services\\"',
+                f'move /y "{inc_dir}\\qubesbuilder-file-copy-out.ps1" "q:\\qubes-rpc-services\\"',
             ]
 
             qrexec_call(

--- a/rpc/qubesbuilder.WinFileCopyIn
+++ b/rpc/qubesbuilder.WinFileCopyIn
@@ -1,1 +1,1 @@
-c:\windows\system32\cmd.exe /c powershell.exe -executionpolicy bypass -noninteractive -file "%QUBES_TOOLS%\qubes-rpc-services\qubesbuilder-file-copy-in.ps1" "%1"
+c:\windows\system32\cmd.exe /c powershell.exe -executionpolicy bypass -noninteractive -file "q:\qubes-rpc-services\qubesbuilder-file-copy-in.ps1" "%1"

--- a/rpc/qubesbuilder.WinFileCopyOut
+++ b/rpc/qubesbuilder.WinFileCopyOut
@@ -1,1 +1,1 @@
-c:\windows\system32\cmd.exe /c powershell.exe -executionpolicy bypass -noninteractive -file "%QUBES_TOOLS%\qubes-rpc-services\qubesbuilder-file-copy-out.ps1" "%1"
+c:\windows\system32\cmd.exe /c powershell.exe -executionpolicy bypass -noninteractive -file "q:\qubes-rpc-services\qubesbuilder-file-copy-out.ps1" "%1"


### PR DESCRIPTION
By default QWT is installed in Program Files which is not writable by standard users. Use the override RPC location in the private volume instead.