### PR TITLE
add `docker-cli`

### DIFF
--- a/dependencies-debian.txt
+++ b/dependencies-debian.txt
@@ -1,6 +1,7 @@
 createrepo-c
 devscripts
 docker.io
+docker-cli
 gpg
 mktorrent
 openssl


### PR DESCRIPTION
This is to make it compatible with `apt --no-install-recommends`.