### PR TITLE
Config changes for Whonix 18 / Kicksecure 18

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -495,14 +495,14 @@ qubes-template-fedora-40-xfce:
 qubes-template-debian-12:
   extends: .template_qubes_job
 
-qubes-template-whonix-gateway-17:
+qubes-template-whonix-gateway-18:
   extends: .template_qubes_job
 
-qubes-template-whonix-workstation-17:
+qubes-template-whonix-workstation-18:
   extends: .template_qubes_job
   allow_failure: true
 
-qubes-template-kicksecure-17:
+qubes-template-kicksecure-18:
   extends: .template_qubes_job
   allow_failure: true
 

--- a/example-configs/kicksecure.yml
+++ b/example-configs/kicksecure.yml
@@ -14,11 +14,11 @@ verbose: true
 qubes-release: r4.3
 
 distributions:
-  - vm-bookworm
+  - vm-trixie
 
 templates:
-  - kicksecure-17:
-      dist: bookworm
+  - kicksecure-18:
+      dist: trixie
       flavor: kicksecure
       options:
         - minimal
@@ -29,7 +29,7 @@ components:
       packages: False
   - template-kicksecure:
       packages: False
-      branch: master
+      branch: trixie
       url: https://github.com/Kicksecure/qubes-template-kicksecure.git
       maintainers:
         # Patrick (adrelanos)

--- a/example-configs/qubes-os-main.yml
+++ b/example-configs/qubes-os-main.yml
@@ -32,15 +32,15 @@ templates:
       flavor: xfce
       options:
         - firmware
-  - whonix-gateway-17:
-      dist: bookworm
+  - whonix-gateway-18:
+      dist: trixie
       flavor: whonix-gateway
       options:
         - minimal
         - no-recommends
         - install-kernel
-  - whonix-workstation-17:
-      dist: bookworm
+  - whonix-workstation-18:
+      dist: trixie
       flavor: whonix-workstation
       options:
         - minimal
@@ -56,7 +56,7 @@ components:
       branch: main
   - template-whonix:
       packages: False
-      branch: master
+      branch: trixie
       url: https://github.com/Whonix/qubes-template-whonix
       maintainers:
         - '916B8D99C38EAF5E8ADC7A2A8D66066A2EEACCDA'

--- a/example-configs/qubes-os-r4.2.yml
+++ b/example-configs/qubes-os-r4.2.yml
@@ -53,7 +53,7 @@ components:
       branch: main
   - template-whonix:
       packages: False
-      branch: master
+      branch: bookworm
       url: https://github.com/Whonix/qubes-template-whonix
       maintainers:
         - '916B8D99C38EAF5E8ADC7A2A8D66066A2EEACCDA'

--- a/example-configs/qubes-os-r4.3.yml
+++ b/example-configs/qubes-os-r4.3.yml
@@ -30,14 +30,14 @@ templates:
       flavor: xfce
       options:
         - firmware
-  - whonix-gateway-17:
-      dist: bookworm
+  - whonix-gateway-18:
+      dist: trixie
       flavor: whonix-gateway
       options:
         - minimal
         - no-recommends
-  - whonix-workstation-17:
-      dist: bookworm
+  - whonix-workstation-18:
+      dist: trixie
       flavor: whonix-workstation
       options:
         - minimal
@@ -52,7 +52,7 @@ components:
       branch: main
   - template-whonix:
       packages: False
-      branch: master
+      branch: trixie
       url: https://github.com/Whonix/qubes-template-whonix
       maintainers:
         - '916B8D99C38EAF5E8ADC7A2A8D66066A2EEACCDA'

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -163,6 +163,7 @@ less-secure-signed-commits-sufficient:
   - builder-debian
   - builder-archlinux
   - template-whonix
+  - template-kicksecure
   - python-qasync
   - core-vchan-xen
   - core-qrexec

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -71,12 +71,12 @@ components:
   - template-whonix:
       packages: False
       url: https://github.com/Whonix/qubes-template-whonix
-      branch: master
+      branch: trixie
       maintainers:
         - 916B8D99C38EAF5E8ADC7A2A8D66066A2EEACCDA
   - template-kicksecure:
       packages: False
-      branch: master
+      branch: trixie
       url: https://github.com/Kicksecure/qubes-template-kicksecure.git
       maintainers:
         - 916B8D99C38EAF5E8ADC7A2A8D66066A2EEACCDA
@@ -137,20 +137,20 @@ templates:
   - debian-12-minimal:
       dist: bookworm
       flavor: minimal
-  - whonix-gateway-17:
-      dist: bookworm
+  - whonix-gateway-18:
+      dist: trixie
       flavor: whonix-gateway
       options:
         - minimal
         - no-recommends
-  - whonix-workstation-17:
-      dist: bookworm
+  - whonix-workstation-18:
+      dist: trixie
       flavor: whonix-workstation
       options:
         - minimal
         - no-recommends
-  - kicksecure-17:
-      dist: bookworm
+  - kicksecure-18:
+      dist: trixie
       flavor: kicksecure
       options:
         - minimal

--- a/tests/test_cli_repository.py
+++ b/tests/test_cli_repository.py
@@ -141,7 +141,7 @@ def test_repository_create_template(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-t",
-            "whonix-gateway-17",
+            "whonix-gateway-18",
             "repository",
             "create",
             "templates-community-testing",


### PR DESCRIPTION
Adjust branch names, to have version 18 in R4.3 while keeping version 17 in
R4.2. See individual commits for details.

QubesOS/qubes-issues#10253