### PR TITLE
Fix chroot cache path

### DIFF
--- a/qubesbuilder/plugins/build_archlinux/__init__.py
+++ b/qubesbuilder/plugins/build_archlinux/__init__.py
@@ -298,7 +298,9 @@ class ArchlinuxBuildPlugin(ArchlinuxDistributionPlugin, BuildPlugin):
                 ),
             }
 
-            chroot_dir = self.config.cache_dir / "chroot" / self.dist.name
+            chroot_dir = (
+                self.config.cache_dir / "chroot" / self.dist.distribution
+            )
             chroot_archive = "root.tar.gz"
 
             if (chroot_dir / chroot_archive).exists():

--- a/qubesbuilder/plugins/build_deb/__init__.py
+++ b/qubesbuilder/plugins/build_deb/__init__.py
@@ -276,7 +276,7 @@ class DEBBuildPlugin(DEBDistributionPlugin, BuildPlugin):
             #  This is until we use shlex.quote.
 
             # Add downloaded packages and prepared chroot cache
-            chroot_dir = self.config.cache_dir / "chroot" / self.dist.name
+            chroot_dir = self.config.cache_dir / "chroot" / self.dist.distribution
             aptcache_dir = chroot_dir / "pbuilder/aptcache"
             base_tgz = chroot_dir / "pbuilder/base.tgz"
             if aptcache_dir.exists():


### PR DESCRIPTION
The chroot cache path was changed from just distribution code name to
full package set (so, "vm-bookworm" instead of just "bookworm"). But
that change missed few spots. Adjust them too.

Fixes: fd81b5c "Do package init-cache automatically"