### PR TITLE
tests: switch CI tests to use example-advanced component

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,13 @@ include:
   - file: /common.yml
     project: QubesOS/qubes-continuous-integration
 
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^test(-.*)?$/
+      variables:
+        CI_RUN_ALL_JOBS: "1"
+    - when: always
+
 stages:
   - test
   - prep
@@ -15,22 +22,30 @@ variables:
   DEBUG: "1"
   GIT_SUBMODULE_STRATEGY: recursive
   CI_RUN_PYTEST_JOBS:
+    value: "1"
     description: "Run all pytest jobs, default: 1"
   CI_RUN_COMPONENT_JOBS:
+    value: "0"
     description: "Run components jobs, default: 0"
   CI_RUN_TEMPLATE_JOBS:
+    value: "0"
     description: "Run template jobs, default: 0"
   CI_RUN_CACHE_JOBS:
+    value: "0"
     description: "Run cache jobs, subset of CI_RUN_COMPONENT_JOBS, default: 0"
   CI_RUN_ISO_JOBS:
+    value: "0"
     description: "Run ISO jobs, default: 0"
   CI_RUN_INFRA_JOBS:
+    value: "0"
     description: "Run all builderv2-github jobs, default: 0"
   CI_RUN_WINDOWS_JOBS:
+    value: "0"
     description: "Run Windows build jobs, default: 0"
   CI_RUN_ANSIBLE_JOBS:
     description: "Run Ansible deployment tests, default: 0"
   CI_RUN_ALL_JOBS:
+    value: "0"
     description: "Run all jobs, default: 0"
 
 builderv2-github:
@@ -448,9 +463,6 @@ cache-host-fc41:
     - !reference [.init_cache_job, script ]
     - tests/scripts/check-chroot-content.sh artifacts "${CI_JOB_NAME#cache-}" /usr/bin/gcc
 
-cache-vm-fc40:
-  extends: .init_cache_job
-
 cache-vm-fc41:
   extends: .init_cache_job
 
@@ -488,10 +500,10 @@ podman-host-fc37:
   needs:
     - cache-host-fc37
 
-podman-vm-fc40:
+podman-vm-fc43:
   extends: .component_podman_job
   needs:
-    - cache-vm-fc40
+    - cache-vm-fc43
 
 #podman-vm-bookworm:
 #  extends: .component_podman_job
@@ -503,10 +515,10 @@ docker-host-fc37:
   needs:
     - cache-host-fc37
 
-docker-vm-fc40:
+docker-vm-fc43:
   extends: .component_docker_job
   needs:
-    - cache-vm-fc40
+    - cache-vm-fc43
 
 docker-vm-bookworm:
   extends: .component_docker_job
@@ -530,7 +542,7 @@ docker-vm-jammy:
     # install an update manually built until https://bugzilla.redhat.com/show_bug.cgi?id=2108872 is handled
     - sudo dnf update -y https://salmon.qubes-os.org/~marmarek/reprepro-5.4.2-1.fc37.x86_64.rpm
   variables:
-    QB_EXTRA_ARGS: "-o executor:options:image=qubes-builder-debian:latest -o +components+vmm-xen-guest -c vmm-xen-guest -c core-vchan-xen"
+    QB_EXTRA_ARGS: "-o executor:options:image=qubes-builder-debian:latest"
   needs:
     - cache-vm-jammy
 
@@ -546,7 +558,7 @@ docker-vm-noble:
     # install an update manually built until https://bugzilla.redhat.com/show_bug.cgi?id=2108872 is handled
     - sudo dnf update -y https://salmon.qubes-os.org/~marmarek/reprepro-5.4.2-1.fc37.x86_64.rpm
   variables:
-    QB_EXTRA_ARGS: "-o executor:options:image=qubes-builder-ubuntu:latest -o +components+vmm-xen-guest -c vmm-xen-guest -c core-vchan-xen"
+    QB_EXTRA_ARGS: "-o executor:options:image=qubes-builder-ubuntu:latest"
   needs:
     - cache-vm-noble
 
@@ -557,10 +569,10 @@ qubes-host-fc37:
   needs:
     - cache-host-fc37
 
-qubes-vm-fc40:
+qubes-vm-fc43:
   extends: .component_qubes_job
   needs:
-    - cache-vm-fc40
+    - cache-vm-fc43
 
 qubes-vm-bookworm:
   extends: .component_qubes_job
@@ -570,7 +582,7 @@ qubes-vm-bookworm:
 qubes-vm-win10:
   extends: .windows_build_job
   variables:
-    QB_EXTRA_ARGS: "-c vmm-xen-windows-pvdrivers"
+    QB_EXTRA_ARGS: "-c example-advanced"
 
 # Local executor
 
@@ -579,10 +591,10 @@ local-host-fc37:
   needs:
     - cache-host-fc37
 
-local-vm-fc40:
+local-vm-fc43:
   extends: .component_local_job
   needs:
-    - cache-vm-fc40
+    - cache-vm-fc43
 
 local-vm-bookworm:
   extends: .component_local_job

--- a/qubesbuilder/plugins/source_deb/__init__.py
+++ b/qubesbuilder/plugins/source_deb/__init__.py
@@ -195,11 +195,21 @@ class DEBSourcePlugin(DEBDistributionPlugin, SourcePlugin):
                 source_debian = f"{package_release_name_full}.tar.xz"
             else:
                 source_debian = f"{package_release_name_full}.debian.tar.xz"
-            if parameters.get("files", []):
-                # FIXME: The first file is the source archive. Is it valid for all the cases?
+
+            # Create archive only if no external files are provided or if
+            # explicitly requested.
+            create_archive = not parameters.get("files", [])
+            create_archive = parameters.get("create-archive", create_archive)
+
+            archive_extensions = (".gz", ".bz2", ".xz", ".lzma2")
+            if not create_archive and parameters.get("files", []):
+                # The first file is expected to be the source archive.
                 ext = Path(get_archive_name(parameters["files"][0])).suffix
-                msg = f"{self.component}:{self.dist}:{directory}: Invalid extension '{ext}'."
-                if ext not in (".gz", ".bz2", ".xz", ".lzma2"):
+                msg = (
+                    f"{self.component}:{self.dist}:{directory}:"
+                    f" Invalid extension '{ext}'."
+                )
+                if ext not in archive_extensions:
                     raise SourceError(msg)
             else:
                 ext = ".gz"
@@ -260,21 +270,32 @@ class DEBSourcePlugin(DEBDistributionPlugin, SourcePlugin):
                         f"{self.executor.get_plugins_dir()}/source/salt/FORMULA-DEFAULTS {source_dir}/FORMULA"
                     ]
 
-                # Create archive only if no external files are provided or if explicitly requested.
-                create_archive = not parameters.get("files", [])
-                create_archive = parameters.get(
-                    "create-archive", create_archive
-                )
                 if create_archive:
                     cmd += [
                         f"{self.executor.get_plugins_dir()}/fetch/scripts/create-archive {source_dir} {source_orig}",
                         f"mv {source_dir}/{source_orig} {self.executor.get_builder_dir()}",
                     ]
-                for file in parameters.get("files", []):
-                    fn = get_archive_name(file)
-                    cmd.append(
-                        f"mv {self.executor.get_distfiles_dir() / self.component.name / fn} {self.executor.get_builder_dir()}/{source_orig}"
-                    )
+                    # Extra distfiles (non-archive) are moved into the source
+                    # directory so debian/rules can reference them.
+                    for file in parameters.get("files", []):
+                        fn = get_archive_name(file)
+                        cmd.append(
+                            f"mv {self.executor.get_distfiles_dir() / self.component.name / fn} {source_dir}"
+                        )
+                else:
+                    # The first file replaces the orig archive; remaining files
+                    # are extra distfiles moved into the source directory.
+                    files = parameters.get("files", [])
+                    if files:
+                        fn = get_archive_name(files[0])
+                        cmd.append(
+                            f"mv {self.executor.get_distfiles_dir() / self.component.name / fn} {self.executor.get_builder_dir()}/{source_orig}"
+                        )
+                    for file in files[1:]:
+                        fn = get_archive_name(file)
+                        cmd.append(
+                            f"mv {self.executor.get_distfiles_dir() / self.component.name / fn} {source_dir}"
+                        )
 
             # Update changelog, after create-archive
             cmd += [

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,30 +1,202 @@
 #!/bin/bash
 # Run tests locally exactly as GitLab CI would.
-# Usage: ./run-tests.sh [PYTEST_TARGETS]
-# Example: ./run-tests.sh "tests/test_check_release_status.py"
+#
+# Usage:
+#   ./run-tests.sh [PYTEST_TARGETS]             Run pytest jobs
+#   ./run-tests.sh prepare-cache [DIR]          Init chroot caches
+#   ./run-tests.sh cache <dist>                 Run a single cache CI job
+#   ./run-tests.sh component <executor> <dist>  Run a component build CI job
+#   ./run-tests.sh windows <dist>               Run a Windows build CI job
+#   ./run-tests.sh template <template-name>     Run a template build CI job
+#
+# Executors: docker | podman | qubes | local
+#
+# Examples:
+#   ./run-tests.sh component docker vm-fc43
+#   ./run-tests.sh component qubes vm-bookworm
+#   ./run-tests.sh component local host-fc37
+#   ./run-tests.sh windows vm-win10
+#   ./run-tests.sh cache vm-bookworm
+#   ./run-tests.sh template fedora-43-xfce
 
 set -e
 
 CI_PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PYTEST_TARGETS="${*:-tests/}"
+BUILDER_CONF="$CI_PROJECT_DIR/tests/builder-ci.yml"
+RELEASE="${RELEASE:-4.3}"
 
-PYTEST_ARGS=(
-    -vv --color=yes --showlocals
-    --tb=long
-    --capture=no
-    -rA
-    -o truncation_limit_chars=0
-    -o truncation_limit_lines=0
-    -o junit_logging=all
-    --junitxml=artifacts/qubesbuilder.xml
-)
+die() { echo "ERROR: $*" >&2; exit 1; }
 
-# before_script
-mkdir -p "$CI_PROJECT_DIR/artifacts"
-mkdir -p ~/results ~/tmp
+setup_gnupg() {
+    export GNUPGHOME="$CI_PROJECT_DIR/tests/gnupg"
+}
 
-# script
-# shellcheck disable=SC2086
-PYTHONPATH=".:$PYTHONPATH" BASE_ARTIFACTS_DIR=~/results TMPDIR=~/tmp \
-    pytest-3 "${PYTEST_ARGS[@]}" $PYTEST_TARGETS 2>&1 | tee artifacts/pytest.log
-exit "${PIPESTATUS[0]}"
+setup_docker_image() {
+    docker pull registry.gitlab.com/qubesos/docker-images/qubes-builder-fedora:latest
+    docker tag  registry.gitlab.com/qubesos/docker-images/qubes-builder-fedora:latest qubes-builder-fedora:latest
+}
+
+setup_podman_image() {
+    podman pull docker.io/fepitre/qubes-builder-fedora:latest
+    podman tag  docker.io/fepitre/qubes-builder-fedora:latest qubes-builder-fedora:latest
+}
+
+setup_ubuntu_docker_image() {
+    docker pull registry.gitlab.com/qubesos/docker-images/qubes-builder-ubuntu:latest
+    docker tag  registry.gitlab.com/qubesos/docker-images/qubes-builder-ubuntu:latest qubes-builder-ubuntu:latest
+}
+
+setup_debian_docker_image() {
+    docker pull registry.gitlab.com/qubesos/docker-images/qubes-builder-debian:latest
+    docker tag  registry.gitlab.com/qubesos/docker-images/qubes-builder-debian:latest qubes-builder-debian:latest
+}
+
+qb() {
+    PYTHONPATH=".:${PYTHONPATH:-}" python3 "$CI_PROJECT_DIR/qb" \
+        --builder-conf "$BUILDER_CONF" "$@"
+}
+
+prepare_cache() {
+    local cache_dir="${1:-$HOME/qb-cache}"
+    local dists=(host-fc37 vm-bookworm vm-trixie vm-archlinux)
+
+    mkdir -p "$cache_dir"
+    for dist in "${dists[@]}"; do
+        qb --option "artifacts-dir=$cache_dir" -d "$dist" package init-cache
+    done
+}
+
+run_cache() {
+    local dist="${1:?dist required}"
+    setup_docker_image
+    qb \
+        -o "use-qubes-repo:version=${RELEASE}" \
+        -o "qubes-release=r${RELEASE}" \
+        -o "+distributions+${dist}" \
+        -d "$dist" \
+        package init-cache
+}
+
+run_component() {
+    local executor="${1:?executor required (docker|podman|qubes|local)}"
+    local dist="${2:?dist required}"
+    local qb_extra_args=()
+
+    setup_gnupg
+
+    case "$executor" in
+        docker)
+            case "$dist" in
+                vm-jammy)
+                    setup_debian_docker_image
+                    qb_extra_args=(-o "executor:options:image=qubes-builder-debian:latest")
+                    ;;
+                vm-noble)
+                    setup_ubuntu_docker_image
+                    qb_extra_args=(-o "executor:options:image=qubes-builder-ubuntu:latest")
+                    ;;
+                *)
+                    setup_docker_image
+                    ;;
+            esac
+            qb -d "$dist" "${qb_extra_args[@]}" package all
+            ;;
+        podman)
+            setup_podman_image
+            local tmp_conf
+            tmp_conf=$(mktemp --suffix=.yml)
+            sed 's/docker/podman/' "$BUILDER_CONF" > "$tmp_conf"
+            BUILDER_CONF="$tmp_conf" qb -d "$dist" "${qb_extra_args[@]}" package all
+            rm -f "$tmp_conf"
+            ;;
+        qubes)
+            local dispvm="${DISPVM:-builder-dvm}"
+            qb -d "$dist" \
+                -o executor:type=qubes \
+                -o "executor:options:dispvm=$dispvm" \
+                "${qb_extra_args[@]}" package all
+            ;;
+        local)
+            local tmpdir="${LOCAL_TMP:-$HOME/tmp}"
+            mkdir -p "$tmpdir"
+            qb -d "$dist" \
+                -o executor:type=local \
+                -o "executor:options:directory=$tmpdir" \
+                "${qb_extra_args[@]}" package all
+            ;;
+        *)
+            die "unknown executor '$executor': choose docker podman qubes local"
+            ;;
+    esac
+}
+
+run_windows() {
+    local dist="${1:?dist required}"
+    local dispvm="${DISPVM:-builder-dvm}"
+
+    setup_gnupg
+
+    qb -d "$dist" -c example-advanced \
+        -o executor:type=qubes \
+        -o "executor:options:dispvm=$dispvm" \
+        package fetch init-cache prep
+
+    qb -d "$dist" -c example-advanced package build
+
+    qb -d "$dist" -c example-advanced \
+        -o executor:type=qubes \
+        -o "executor:options:dispvm=$dispvm" \
+        package sign publish
+}
+
+run_template() {
+    local tmpl="${1:?template name required}"
+    local dispvm="${DISPVM:-builder-dvm}"
+
+    setup_gnupg
+    setup_docker_image
+
+    qb -c builder-rpm -c builder-debian -c template-whonix \
+       -c template-kicksecure -c builder-archlinux -c qubes-release \
+       package fetch
+
+    qb \
+        -o "use-qubes-repo:version=${RELEASE}" \
+        -o "qubes-release=r${RELEASE}" \
+        -t "$tmpl" \
+        -o executor:type=qubes \
+        -o "executor:options:dispvm=$dispvm" \
+        template all
+}
+
+run_pytest() {
+    local pytest_args=(
+        -vv --color=yes --showlocals
+        --tb=long
+        --capture=no
+        -rA
+        -o truncation_limit_chars=0
+        -o truncation_limit_lines=0
+        -o junit_logging=all
+        --junitxml=artifacts/qubesbuilder.xml
+    )
+
+    if [[ -n "${CACHE_ARTIFACTS_DIR:-}" ]]; then
+        pytest_args+=(--cache-dir "$CACHE_ARTIFACTS_DIR")
+    fi
+
+    mkdir -p "$CI_PROJECT_DIR/artifacts" ~/tmp
+
+    PYTHONPATH=".:${PYTHONPATH:-}" BASE_ARTIFACTS_DIR=~/results TMPDIR=~/tmp \
+        pytest-3 "${pytest_args[@]}" "${@:-tests/}" 2>&1 | tee artifacts/pytest.log
+    exit "${PIPESTATUS[0]}"
+}
+
+case "${1:-}" in
+    prepare-cache) shift; prepare_cache "$@" ;;
+    cache)         shift; run_cache "$@" ;;
+    component)     shift; run_component "$@" ;;
+    windows)       shift; run_windows "$@" ;;
+    template)      shift; run_template "$@" ;;
+    *)             run_pytest "$@" ;;
+esac

--- a/tests/builder-ci.yml
+++ b/tests/builder-ci.yml
@@ -33,14 +33,6 @@ sign-key:
 iso:
   kickstart: conf/iso-online-testing.ks
 
-cache:
-  host-fc37:
-    packages:
-      - gcc
-      - python3-devel
-      - python3-sphinx
-      - systemd-devel
-
 distributions:
   - host-fc37
   - vm-win10:
@@ -60,7 +52,6 @@ distributions:
   - vm-bullseye
   - vm-bookworm
   - vm-trixie
-  - vm-fc40
   - vm-fc41
   - vm-fc42
   - vm-fc43
@@ -94,46 +85,14 @@ components:
       url: https://github.com/Kicksecure/qubes-template-kicksecure.git
       maintainers:
         - 916B8D99C38EAF5E8ADC7A2A8D66066A2EEACCDA
-  - builder-archlinux:
-      packages: False
+  - example-advanced:
+      url: https://github.com/fepitre/qubes-example-advanced
+      branch: main
+      maintainers:
+        # fepitre's @invisiblethingslab.com
+        - 77EEEF6D0386962AEA8CF84A9B8273F80AC219E6
   - python-qasync:
       branch: v0.23.0-2
-  - core-vchan-xen
-  - vmm-xen-windows-pvdrivers
-  - core-qrexec:
-      branch: v4.2.25
-  - desktop-linux-xfce4-xfwm4:
-      branch: v4.16.1-4
-  - app-linux-split-gpg:
-      branch: v2.0.67-builderv2-tests
-      url: https://github.com/fepitre/qubes-app-linux-split-gpg
-      min-distinct-maintainers: 3
-      maintainers:
-      - 0064428F455451B3EBE78A7F063938BA42CFA724
-      - 9FA64B92F95E706BF28E2CA6484010B5CDC576E2
-      - C4A2E4615A16BD191110DEE17320B2D2134763F3
-  - linux-gbulb:
-      url: https://github.com/marmarek/qubes-linux-gbulb
-      branch: files-git-builderv2-tests
-      verification-mode: less-secure-signed-commits-sufficient
-  - dummy-component:
-      # disable by default, as most CI jobs build only one dist at a time
-      packages: false
-      url: https://github.com/fepitre/qubes-dummy-component
-      verification-mode: less-secure-signed-commits-sufficient
-      host-fc37:
-        stages:
-          - prep:
-              needs:
-                - component: dummy-component
-                  distribution: vm-fc40
-                  stage: build
-                  build: dummy.spec
-                - component: dummy-component
-                  distribution: vm-fc41
-                  stage: build
-                  build: dummy.spec
-
 
 templates:
   - fedora-43-xfce:
@@ -179,15 +138,11 @@ less-secure-signed-commits-sufficient:
   - builder-archlinux
   - template-whonix
   - template-kicksecure
-  - python-qasync
-  - core-vchan-xen
-  - core-qrexec
-  - desktop-linux-xfce4-xfwm4
-  - app-linux-split-gpg
   - vmm-xen
   - vmm-xen-guest
   - qubes-release
-  - vmm-xen-windows-pvdrivers
+  - example-advanced
+  - python-qasync
 
 repository-publish:
   components: current-testing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,41 @@
 import os
 import pathlib
+import shutil
+import subprocess
 import tempfile
 import uuid
 
 import pytest
+
+# Redirect all temporary files to home
+_default_tmpdir = os.path.join(os.path.expanduser("~"), "qb-test-tmp")
+os.makedirs(_default_tmpdir, exist_ok=True)
+if tempfile.tempdir is None:
+    tempfile.tempdir = os.environ.get("TMPDIR", _default_tmpdir)
+
+
+def _seed_cache(cache_dir: pathlib.Path, artifacts_dir: pathlib.Path):
+    """
+    Hard-link (or copy) cache/chroot from cache_dir into artifacts_dir.
+    """
+    src = cache_dir / "cache" / "chroot"
+    if not src.is_dir():
+        return
+    dst_parent = artifacts_dir / "cache"
+    dst_parent.mkdir(parents=True, exist_ok=True)
+    dst = dst_parent / "chroot"
+    if dst.exists():
+        return  # already seeded
+    try:
+        # Hard-link the tree to not use extra disk space
+        subprocess.run(
+            ["cp", "-al", str(src), str(dst_parent)],
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError:
+        # Fall back to a regular copy (e.g. cross-device).
+        shutil.copytree(str(src), str(dst))
 
 
 def pytest_addoption(parser):
@@ -13,30 +45,61 @@ def pytest_addoption(parser):
         default=None,
         help="Directory to use as qb artifacts-dir",
     )
+    parser.addoption(
+        "--cache-dir",
+        action="store",
+        default=None,
+        help="Directory with pre-built chroot caches to seed into artifacts-dir",
+    )
+
+
+def _get_cache_dir(pytestconfig) -> pathlib.Path | None:
+    opt = pytestconfig.getoption("--cache-dir") or os.environ.get(
+        "CACHE_ARTIFACTS_DIR"
+    )
+    return pathlib.Path(opt) if opt else None
 
 
 @pytest.fixture
-def artifacts_dir_single():
+def artifacts_dir_single(pytestconfig):
+    cache_dir = _get_cache_dir(pytestconfig)
+    if os.environ.get("SINGLE_ARTIFACTS_DIR"):
+        artifacts_dir = pathlib.Path(os.environ["SINGLE_ARTIFACTS_DIR"])
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        if cache_dir:
+            _seed_cache(cache_dir, artifacts_dir)
+        yield artifacts_dir
+        return
     if os.environ.get("BASE_ARTIFACTS_DIR"):
         tmpdir = tempfile.mkdtemp(
             prefix="github-", dir=os.environ["BASE_ARTIFACTS_DIR"]
         )
     else:
-        tmpdir = tempfile.mkdtemp(prefix="github-")
+        default_base = os.path.join(
+            os.path.expanduser("~"), "qb-test-artifacts"
+        )
+        os.makedirs(default_base, exist_ok=True)
+        tmpdir = tempfile.mkdtemp(prefix="github-", dir=default_base)
     artifacts_dir = pathlib.Path(tmpdir) / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
+    if cache_dir:
+        _seed_cache(cache_dir, artifacts_dir)
     yield artifacts_dir
 
 
 @pytest.fixture(scope="session")
 def artifacts_dir(pytestconfig):
     cli_dir = pytestconfig.getoption("--artifacts-dir")
+    cache_dir = _get_cache_dir(pytestconfig)
 
     if cli_dir:
         root = pathlib.Path(cli_dir)
     else:
         base = pathlib.Path(
-            os.environ.get("BASE_ARTIFACTS_DIR", tempfile.gettempdir())
+            os.environ.get(
+                "BASE_ARTIFACTS_DIR",
+                os.path.join(os.path.expanduser("~"), "qb-test-artifacts"),
+            )
         )
         base.mkdir(parents=True, exist_ok=True)
 
@@ -54,4 +117,6 @@ def artifacts_dir(pytestconfig):
         root = base / name / "artifacts"
 
     root.mkdir(parents=True, exist_ok=True)
+    if cache_dir:
+        _seed_cache(cache_dir, root)
     yield root

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import datetime
 import hashlib
-import io
 import itertools
 import os.path
 import pathlib
@@ -13,8 +12,6 @@ import dnf
 import pytest
 import yaml
 from dateutil.parser import parse as parsedate
-from pycdlib import pycdlib
-
 from qubesbuilder.common import PROJECT_PATH
 from tests.conftest import artifacts_dir_single, artifacts_dir
 
@@ -22,100 +19,185 @@ DEFAULT_BUILDER_CONF = PROJECT_PATH / "tests/builder-ci.yml"
 HASH_RE = re.compile(r"[a-f0-9]{40}")
 
 # Version constants: update these when bumping component/template versions
-QREXEC_VERSION = "4.2.25"
+EXAMPLE_VERSION = "1.0.2"
+EXAMPLE_RELEASE = "1"
 FEDORA_MINIMAL = "fedora-43-minimal"
 FEDORA_XFCE = "fedora-43-xfce"
 HOST_FC_DIST = "fc37"
 
-
-def qrexec_rpm(pkg, release=1, devel=None):
-    """
-    Return an RPM filename for a core-qrexec sub-package.
-    """
-    rel = f"{release}.{devel}.{HOST_FC_DIST}" if devel is not None else f"{release}.{HOST_FC_DIST}"
-    return f"{pkg}-{QREXEC_VERSION}-{rel}.x86_64.rpm"
-
-
-def qrexec_srpm(pkg, release=1, devel=None):
-    """
-    Return an SRPM filename for a core-qrexec sub-package.
-    """
-    rel = f"{release}.{devel}.{HOST_FC_DIST}" if devel is not None else f"{release}.{HOST_FC_DIST}"
-    return f"{pkg}-{QREXEC_VERSION}-{rel}.src.rpm"
+# python-qasync version constants
+QASYNC_VERSION = "0.23.0"
+QASYNC_RELEASE = "2"
+QASYNC_DEB_VER = f"{QASYNC_VERSION}-{QASYNC_RELEASE}+deb12u1"
+QASYNC_ORIG = f"python-qasync_{QASYNC_VERSION}.orig.tar.gz"
+QASYNC_DSC = f"python-qasync_{QASYNC_DEB_VER}.dsc"
+QASYNC_DEBIAN = f"python-qasync_{QASYNC_DEB_VER}.debian.tar.xz"
 
 
-def qrexec_deb(pkg, deb_dist="deb12u1", devel=None, arch="amd64", ext="deb"):
+def example_rpm(pkg, release=1, devel=None, arch="x86_64"):
     """
-    Return a .deb / source filename for a core-qrexec package.
+    Return an RPM filename for an example-advanced sub-package.
+    """
+    rel = (
+        f"{release}.{devel}.{HOST_FC_DIST}"
+        if devel is not None
+        else f"{release}.{HOST_FC_DIST}"
+    )
+    return f"{pkg}-{EXAMPLE_VERSION}-{rel}.{arch}.rpm"
+
+
+def example_srpm(pkg, release=1, devel=None):
+    """
+    Return an SRPM filename for an example-advanced sub-package.
+    """
+    rel = (
+        f"{release}.{devel}.{HOST_FC_DIST}"
+        if devel is not None
+        else f"{release}.{HOST_FC_DIST}"
+    )
+    return f"{pkg}-{EXAMPLE_VERSION}-{rel}.src.rpm"
+
+
+def example_deb(pkg, deb_dist="deb12u1", devel=None, arch="amd64", ext="deb"):
+    """
+    Return a .deb / source filename for an example-advanced package.
     """
     devel_suffix = f"+devel{devel}" if devel is not None else ""
-    ver_str = f"{QREXEC_VERSION}-1+{deb_dist}{devel_suffix}"
+    ver_str = f"{EXAMPLE_VERSION}-1+{deb_dist}{devel_suffix}"
     if ext in ("deb", "buildinfo", "changes"):
         return f"{pkg}_{ver_str}_{arch}.{ext}"
     if ext in ("dsc", "debian.tar.xz"):
         return f"{pkg}_{ver_str}.{ext}"
-    return f"{pkg}_{QREXEC_VERSION}.orig.tar.gz"
+    return f"{pkg}_{EXAMPLE_VERSION}.orig.tar.gz"
 
 
-def qrexec_component_dir(artifacts_dir, dist, stage=None, release=1):
+def example_component_dir(artifacts_dir, dist, stage=None, release=1):
     """
-    Return the path to a core-qrexec component artifact directory.
+    Return the path to an example-advanced component artifact directory.
     """
-    base = artifacts_dir / f"components/core-qrexec/{QREXEC_VERSION}-{release}/{dist}"
+    base = (
+        artifacts_dir
+        / f"components/example-advanced/{EXAMPLE_VERSION}-{release}/{dist}"
+    )
     return base / stage if stage else base
 
 
-def qrexec_build_rpms(devel=None):
+def example_dom0_prep_rpms(devel=None):
     """
-    Set of RPMs produced by the qrexec build stage.
-    """
-    return {
-        qrexec_rpm("qubes-core-qrexec", devel=devel),
-        qrexec_rpm("qubes-core-qrexec-debugsource", devel=devel),
-        qrexec_rpm("qubes-core-qrexec-libs", devel=devel),
-        qrexec_rpm("qubes-core-qrexec-libs-debuginfo", devel=devel),
-        qrexec_rpm("qubes-core-qrexec-devel", devel=devel),
-    }
-
-
-def qrexec_prep_rpms(devel=None):
-    """
-    Set of RPMs predicted by the SRPM spec.
-    """
-    return qrexec_build_rpms(devel=devel) | {
-        qrexec_rpm("qubes-core-qrexec-debuginfo", devel=devel),
-        qrexec_rpm("qubes-core-qrexec-libs-debugsource", devel=devel),
-    }
-
-
-def qrexec_dom0_rpms(devel=None):
-    """
-    Set of RPMs for the qubes-core-qrexec-dom0 sub-package.
+    Set of RPMs predicted at prep time for example-dom0 (noarch).
+    query-builtrpms includes debuginfo/debugsource even for noarch packages.
     """
     return {
-        qrexec_rpm("qubes-core-qrexec-dom0", devel=devel),
-        qrexec_rpm("qubes-core-qrexec-dom0-debuginfo", devel=devel),
-        qrexec_rpm("qubes-core-qrexec-dom0-debugsource", devel=devel),
+        example_rpm("qubes-example-dom0", devel=devel, arch="noarch"),
+        example_rpm("qubes-example-dom0-debuginfo", devel=devel, arch="noarch"),
+        example_rpm(
+            "qubes-example-dom0-debugsource", devel=devel, arch="noarch"
+        ),
     }
 
 
-def qrexec_all_signed_rpms(devel=None):
+def example_dom0_build_rpms(devel=None):
     """
-    List of all qrexec RPMs/SRPMs that go through the sign stage.
+    Set of RPMs actually produced by mock for example-dom0 (noarch).
+    mock does not generate debuginfo/debugsource for noarch packages.
+    """
+    return {
+        example_rpm("qubes-example-dom0", devel=devel, arch="noarch"),
+    }
+
+
+def example_dom0_srpm(devel=None):
+    return example_srpm("qubes-example-dom0", devel=devel)
+
+
+def example_vm_build_rpms(devel=None):
+    """
+    Set of RPMs produced by the example-vm build stage (noarch).
+    """
+    return {
+        example_rpm("qubes-example-vm", devel=devel, arch="noarch"),
+    }
+
+
+def example_vm_srpm(devel=None):
+    return example_srpm("qubes-example-vm", devel=devel)
+
+
+def example_libs_build_rpms(devel=None):
+    """
+    Set of RPMs produced by the example-libs build stage (x86_64, with debuginfo).
+    """
+    return {
+        example_rpm("qubes-example-libs", devel=devel),
+        example_rpm("qubes-example-libs-debuginfo", devel=devel),
+        example_rpm("qubes-example-libs-debugsource", devel=devel),
+        example_rpm("qubes-example-libs-devel", devel=devel),
+    }
+
+
+def example_libs_prep_rpms(devel=None):
+    return example_libs_build_rpms(devel=devel)
+
+
+def example_libs_srpm(devel=None):
+    return example_srpm("qubes-example-libs", devel=devel)
+
+
+def example_data_prep_rpms(devel=None):
+    """
+    Set of RPMs predicted at prep time for example-data (noarch, with extra subpackage).
+    query-builtrpms includes debuginfo/debugsource even for noarch packages.
+    """
+    return {
+        example_rpm("qubes-example-data", devel=devel, arch="noarch"),
+        example_rpm("qubes-example-data-extra", devel=devel, arch="noarch"),
+        example_rpm("qubes-example-data-debuginfo", devel=devel, arch="noarch"),
+        example_rpm(
+            "qubes-example-data-debugsource", devel=devel, arch="noarch"
+        ),
+        example_rpm(
+            "qubes-example-data-extra-debuginfo", devel=devel, arch="noarch"
+        ),
+        example_rpm(
+            "qubes-example-data-extra-debugsource", devel=devel, arch="noarch"
+        ),
+    }
+
+
+def example_data_build_rpms(devel=None):
+    """
+    Set of RPMs actually produced by mock for example-data (noarch, with extra subpackage).
+    mock does not generate debuginfo/debugsource for noarch packages.
+    """
+    return {
+        example_rpm("qubes-example-data", devel=devel, arch="noarch"),
+        example_rpm("qubes-example-data-extra", devel=devel, arch="noarch"),
+    }
+
+
+def example_data_srpm(devel=None):
+    return example_srpm("qubes-example-data", devel=devel)
+
+
+def example_host_all_signed_rpms(devel=None):
+    """
+    List of all host RPMs/SRPMs that go through the sign stage.
     """
     return [
-        qrexec_srpm("qubes-core-qrexec", devel=devel),
-        *sorted(qrexec_build_rpms(devel=devel)),
-        qrexec_srpm("qubes-core-qrexec-dom0", devel=devel),
-        *sorted(qrexec_dom0_rpms(devel=devel)),
+        example_dom0_srpm(devel=devel),
+        *sorted(example_dom0_build_rpms(devel=devel)),
+        example_data_srpm(devel=devel),
+        *sorted(example_data_build_rpms(devel=devel)),
     ]
 
 
-def qrexec_repo_dir(artifacts_dir, dist):
+def example_repo_dir(artifacts_dir, dist):
     """
     Local repository directory for a built component.
     """
-    return artifacts_dir / f"repository/{dist}/core-qrexec_{QREXEC_VERSION}"
+    return (
+        artifacts_dir / f"repository/{dist}/example-advanced_{EXAMPLE_VERSION}"
+    )
 
 
 def qb_call(builder_conf, artifacts_dir, *args, **kwargs):
@@ -129,7 +211,15 @@ def qb_call(builder_conf, artifacts_dir, *args, **kwargs):
         f"artifacts-dir={str(artifacts_dir)}",
         *args,
     ]
-    return subprocess.check_call(cmd, **kwargs)
+    check = kwargs.pop("check", True)
+    try:
+        result = subprocess.run(cmd, check=check, **kwargs)
+        return result.returncode
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"Command failed:\n{' '.join(e.cmd)}\n"
+            f"Return code: {e.returncode}"
+        )
 
 
 def qb_call_output(builder_conf, artifacts_dir, *args, **kwargs):
@@ -143,7 +233,14 @@ def qb_call_output(builder_conf, artifacts_dir, *args, **kwargs):
         f"artifacts-dir={str(artifacts_dir)}",
         *args,
     ]
-    return subprocess.check_output(cmd, stderr=subprocess.STDOUT, **kwargs)
+    try:
+        return subprocess.check_output(cmd, stderr=subprocess.STDOUT, **kwargs)
+    except subprocess.CalledProcessError as e:
+        pytest.fail(
+            f"Command failed:\n{' '.join(e.cmd)}\n"
+            f"Return code: {e.returncode}\n"
+            f"Output:\n{e.output.decode() if e.output else ''}"
+        )
 
 
 def deb_packages_list(repository_dir, suite, **kwargs):
@@ -183,7 +280,7 @@ def test_common_config(artifacts_dir):
             f.write("- component2\n")
             f.write("- component3\n")
             f.write("distributions:\n")
-            f.write("- vm-fc40\n")
+            f.write("- vm-fc43\n")
             f.write("- vm-fc37\n")
         include_path = os.path.join(tmpdir, "include-nested.yml")
         with open(include_path, "w") as f:
@@ -199,7 +296,7 @@ def test_common_config(artifacts_dir):
             f.write("- component6\n")
             f.write("- component7\n")
             f.write("distributions:\n")
-            f.write("- vm-fc40\n")
+            f.write("- vm-fc43\n")
             f.write("- vm-fc37\n")
         config_path = os.path.join(tmpdir, "builder.yml")
         with open(config_path, "w") as f:
@@ -239,13 +336,7 @@ def test_common_config(artifacts_dir):
 
 def _get_infos(artifacts_dir):
     infos = {}
-    for component in [
-        "core-qrexec",
-        "core-vchan-xen",
-        "desktop-linux-xfce4-xfwm4",
-        "python-qasync",
-        "app-linux-split-gpg",
-    ]:
+    for component in ["example-advanced"]:
         qb_file = artifacts_dir / "sources" / component / ".qubesbuilder"
         dir_fd = os.open(artifacts_dir / "sources" / component, os.O_RDONLY)
         btime = subprocess.run(
@@ -271,40 +362,13 @@ def test_common_component_fetch(artifacts_dir):
     ).decode()
 
     assert (
-        artifacts_dir / "distfiles/python-qasync/qasync-0.23.0.tar.gz"
-    ).exists()
-    assert (
         artifacts_dir
-        / "distfiles/desktop-linux-xfce4-xfwm4/xfwm4-4.16.1.tar.bz2"
+        / "distfiles/example-advanced/9FA64B92F95E706BF28E2CA6484010B5CDC576E2"
     ).exists()
-    assert (artifacts_dir / "distfiles/linux-gbulb/gbulb-0.6.3.tar.gz").exists()
-    # verify files layout inside
-    subprocess.run(
-        [
-            "tar",
-            "tf",
-            artifacts_dir / "distfiles/linux-gbulb/gbulb-0.6.3.tar.gz",
-            "gbulb-0.6.3/README.rst",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
 
-    for component in [
-        "core-qrexec",
-        "core-vchan-xen",
-        "desktop-linux-xfce4-xfwm4",
-        "python-qasync",
-        "app-linux-split-gpg",
-    ]:
-        assert (
-            artifacts_dir / "sources" / component / ".qubesbuilder"
-        ).exists()
     assert (
-        "Enough distinct tag signatures. Found 3, mandatory minimum is 3."
-        in result
-    )
+        artifacts_dir / "sources" / "example-advanced" / ".qubesbuilder"
+    ).exists()
 
 
 def test_common_component_fetch_updating(artifacts_dir):
@@ -319,13 +383,8 @@ def test_common_component_fetch_updating(artifacts_dir):
         "fetch",
     ).decode()
     for sentence in [
-        "python-qasync: source already fetched. Updating.",
-        "core-vchan-xen: source already fetched. Updating.",
-        "core-qrexec: source already fetched. Updating.",
-        "app-linux-split-gpg: source already fetched. Updating.",
-        "desktop-linux-xfce4-xfwm4: source already fetched. Updating.",
-        "python-qasync: file qasync-0.23.0.tar.gz already downloaded. Skipping.",
-        "desktop-linux-xfce4-xfwm4: file xfwm4-4.16.1.tar.bz2 already downloaded. Skipping.",
+        "example-advanced: source already fetched. Updating.",
+        "example-advanced: file 9FA64B92F95E706BF28E2CA6484010B5CDC576E2 already downloaded. Skipping.",
     ]:
         assert sentence in result
 
@@ -352,20 +411,10 @@ def test_common_component_fetch_inplace_updating(artifacts_dir):
     ).decode()
 
     for sentence in [
-        "python-qasync: source already fetched. Updating.",
-        "core-vchan-xen: source already fetched. Updating.",
-        "core-qrexec: source already fetched. Updating.",
-        "app-linux-split-gpg: source already fetched. Updating.",
-        "desktop-linux-xfce4-xfwm4: source already fetched. Updating.",
-        "python-qasync: file qasync-0.23.0.tar.gz already downloaded. Skipping.",
-        "desktop-linux-xfce4-xfwm4: file xfwm4-4.16.1.tar.bz2 already downloaded. Skipping.",
+        "example-advanced: source already fetched. Updating.",
+        "example-advanced: file 9FA64B92F95E706BF28E2CA6484010B5CDC576E2 already downloaded. Skipping.",
     ]:
         assert sentence in result
-
-    assert (
-        "Enough distinct tag signatures. Found 3, mandatory minimum is 3."
-        in result
-    )
 
     infos_after = _get_infos(artifacts_dir)
 
@@ -392,40 +441,37 @@ def test_common_component_fetch_skip_files(artifacts_dir_single):
 
     _get_infos(artifacts_dir)
 
-    for component in [
-        "core-qrexec",
-        "core-vchan-xen",
-        "desktop-linux-xfce4-xfwm4",
-        "python-qasync",
-        "app-linux-split-gpg",
-    ]:
-        assert (
-            artifacts_dir / "sources" / component / ".qubesbuilder"
-        ).exists()
-        assert not list((artifacts_dir / "distfiles" / component).iterdir())
     assert (
-        "Enough distinct tag signatures. Found 3, mandatory minimum is 3."
-        in result
+        artifacts_dir / "sources" / "example-advanced" / ".qubesbuilder"
+    ).exists()
+    # With skip-files-fetch, external source files must not be downloaded;
+    # submodule archives are part of the source fetch and are allowed.
+    distfiles = list(
+        (artifacts_dir / "distfiles" / "example-advanced").iterdir()
+    )
+    assert not any(
+        f.name == "9FA64B92F95E706BF28E2CA6484010B5CDC576E2" for f in distfiles
     )
 
 
 def test_common_component_fetch_commit_fresh(artifacts_dir_single):
     artifacts_dir = artifacts_dir_single
-    commit_sha = "0589ae8a242b3be6a1b8985c6eb8900e5236152a"
+    # Fetch a known tag and verify the exact commit hash is recorded.
+    commit_sha = "fc06221c83b3374d9a51c39c786fd80ce3b13f41"
     qb_call_output(
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "core-qrexec",
+        "example-advanced",
         "-o",
-        f"+components+core-qrexec:branch={commit_sha}",
+        f"+components+example-advanced:branch=v1.0.2-1",
         "package",
         "fetch",
     ).decode()
 
     fetch_artifact = (
         artifacts_dir
-        / "components/core-qrexec/4.2.20-1/nodist/fetch/source.fetch.yml"
+        / f"components/example-advanced/{EXAMPLE_VERSION}-{EXAMPLE_RELEASE}/nodist/fetch/source.fetch.yml"
     )
     assert fetch_artifact.exists()
     with open(fetch_artifact) as f:
@@ -445,142 +491,58 @@ def test_common_existent_command(artifacts_dir):
 
 
 def test_common_non_existent_command(artifacts_dir):
-    with pytest.raises(subprocess.CalledProcessError):
-        result = qb_call(
-            DEFAULT_BUILDER_CONF, artifacts_dir, "non-existent-command"
-        )
-        assert result == 2
+    result = qb_call(
+        DEFAULT_BUILDER_CONF, artifacts_dir, "non-existent-command", check=False
+    )
+    assert result == 2
 
 
 def test_common_non_existent_component(artifacts_dir):
-    with pytest.raises(subprocess.CalledProcessError):
-        result = qb_call(
-            DEFAULT_BUILDER_CONF,
-            artifacts_dir,
-            "-c",
-            "non-existent-component",
-            "package",
-            "all",
-        )
-        assert result == 2
-
-
-def test_common_component_dependencies_01(artifacts_dir_single):
-    artifacts_dir = artifacts_dir_single
-    dist_artifacts_dir = (
-        artifacts_dir / "components" / "dummy-component" / "1.2.3-4"
-    )
-
-    # Directories for vm-fc40 (hardcoded in dummy-component .qubesbuilder)
-    fc40_dir = dist_artifacts_dir / "vm-fc40" / "build"
-    fc40_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create empty file
-    (fc40_dir / "dummy.spec.build.yml").write_text(
-        yaml.dump({"files": ["some.exe"]})
-    )
-
-    # Write executable content to "some.exe"
-    (fc40_dir / "some.exe").write_text("some executable")
-
-    # Directories for vm-fc41
-    fc41_dir = dist_artifacts_dir / "vm-fc41" / "build"
-    fc41_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create empty file
-    (fc41_dir / "dummy.spec.build.yml").write_text(
-        yaml.dump({"files": ["another.exe"]})
-    )
-
-    # Write executable content to "another.exe"
-    (fc41_dir / "another.exe").write_text("another executable")
-
-    qb_call(
+    result = qb_call(
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "dummy-component",
-        "-o",
-        "+components+dummy-component:packages=true",
-        "-d",
-        "host-fc37",
+        "non-existent-component",
         "package",
-        "fetch",
-        "prep",
-        "build",
+        "all",
+        check=False,
     )
+    assert result == 1
 
-    rpm = (
-        dist_artifacts_dir
-        / "host-fc37"
-        / "build"
-        / "rpm"
-        / "qubes-windows-tools-1.2.3-4.fc37.noarch.rpm"
-    )
-    p1 = subprocess.Popen(
-        ["rpm2cpio", str(rpm)],
-        cwd=str(dist_artifacts_dir),
-        stdout=subprocess.PIPE,
-    )
-    p2 = subprocess.Popen(
-        ["cpio", "-idmv"], cwd=str(dist_artifacts_dir), stdin=p1.stdout
-    )
-    p1.stdout.close()
-    p2.communicate()
 
-    iso_path = (
-        dist_artifacts_dir / "usr" / "lib" / "qubes" / "qubes-windows-tools.iso"
-    )
-    assert (
-        iso_path.exists()
-    ), f"ISO file not found at expected location: {iso_path}"
+def test_common_component_dependencies_01(artifacts_dir_single):
+    # Test that example-advanced Windows build stage artifacts can be pre-staged
+    # and that the pipeline correctly resolves vm-win10 dist-specific build outputs.
+    # This valides the pipeline artifact "needs" path for Windows components.
+    artifacts_dir = artifacts_dir_single
+    win_dist_dir = example_component_dir(artifacts_dir, "vm-win10", stage=None)
 
-    def get_joliet_filenames(iso):
-        children = iso.list_children(joliet_path="/")
-        filenames = []
-        for child in children:
-            raw = child.file_identifier()
-            try:
-                name = raw.decode("utf-16-be")
-            except Exception:
-                name = raw.decode("latin1")
-            filenames.append(name)
-        return filenames
+    # Pre-stage fake Windows build artifacts as the Windows executor would produce them.
+    win_build_dir = win_dist_dir / "build"
+    win_build_dir.mkdir(parents=True, exist_ok=True)
 
-    iso = pycdlib.PyCdlib()
-    iso.open(str(iso_path))
-    expected_files = {
-        "qubes-tools-win10-1.2.3-4.exe": "some executable",
-        "qubes-tools-win11-1.2.3-4.exe": "another executable",
-    }
-    filenames = get_joliet_filenames(iso)
+    dll_rel = "windows/vs2022/x64/Release/example-dummy/example-dummy.dll"
+    lib_rel = "windows/vs2022/x64/Release/example-dummy/example-dummy.lib"
 
-    for expected_name, expected_content in expected_files.items():
-        if expected_name not in filenames:
-            iso.close()
-            raise AssertionError(
-                f"Expected file '{expected_name}' not found in ISO. Found files: {filenames}"
-            )
-        fp = io.BytesIO()
-        joliet_path = "/" + expected_name
-        try:
-            iso.get_file_from_iso_fp(fp, joliet_path=joliet_path)
-            fp.seek(0)
-            content = fp.read().decode("utf-8").strip()
-        except pycdlib.pycdlibexception.PyCdlibException:
-            iso.close()
-            raise AssertionError(
-                f"Expected file '{joliet_path}' not found in ISO."
-            )
-        assert (
-            content == expected_content
-        ), f"Content mismatch for {expected_name}: expected '{expected_content}', got '{content}'"
+    win_build_yml = win_build_dir / "example-advanced.sln.build.yml"
+    win_build_yml.write_text(yaml.dump({"files": [dll_rel, lib_rel]}))
 
-    iso.close()
+    dll_path = win_build_dir / dll_rel
+    dll_path.parent.mkdir(parents=True, exist_ok=True)
+    dll_path.write_bytes(b"\x4d\x5a\x00\x00")  # minimal MZ header stub
+
+    lib_path = win_build_dir / lib_rel
+    lib_path.parent.mkdir(parents=True, exist_ok=True)
+    lib_path.write_bytes(b"\x21\x3c\x61\x72")  # minimal AR stub
+
+    # Verify the fake artifacts are present at the expected pipeline locations.
+    assert win_build_yml.exists()
+    assert dll_path.exists()
+    assert lib_path.exists()
 
 
 #
-# Pipeline for core-qrexec and host-fc37
+# Pipeline for example-advanced and host-fc37
 #
 
 
@@ -606,7 +568,7 @@ def test_component_host_fc37_prep(artifacts_dir):
         "-c",
         "qubes-release",
         "-c",
-        "core-qrexec",
+        "example-advanced",
         "-d",
         "host-fc37",
         "package",
@@ -614,75 +576,72 @@ def test_component_host_fc37_prep(artifacts_dir):
         "prep",
     )
 
-    prep_dir = qrexec_component_dir(artifacts_dir, "host-fc37", "prep")
+    prep_dir = example_component_dir(artifacts_dir, "host-fc37", "prep")
 
-    with open(prep_dir / "rpm_spec_qubes-qrexec.spec.prep.yml") as f:
+    with open(prep_dir / "rpm_spec_example-dom0.spec.prep.yml") as f:
         info = yaml.safe_load(f.read())
 
-    assert set(info.get("rpms", [])) == qrexec_prep_rpms()
+    assert set(info.get("rpms", [])) == example_dom0_prep_rpms()
     assert HASH_RE.match(info.get("source-hash", None))
-    assert info.get("srpm", None) == qrexec_srpm("qubes-core-qrexec")
+    assert info.get("srpm", None) == example_dom0_srpm()
 
-    with open(prep_dir / "rpm_spec_qubes-qrexec-dom0.spec.prep.yml") as f:
+    with open(prep_dir / "rpm_spec_example-data.spec.prep.yml") as f:
         info = yaml.safe_load(f.read())
 
-    assert set(info.get("rpms", [])) == qrexec_dom0_rpms()
+    assert set(info.get("rpms", [])) == example_data_prep_rpms()
     assert HASH_RE.match(info.get("source-hash", None))
-    assert info.get("srpm", None) == qrexec_srpm("qubes-core-qrexec-dom0")
+    assert info.get("srpm", None) == example_data_srpm()
 
 
 def test_component_host_fc37_build(artifacts_dir):
+    # Clean stale build artifacts and local repository so the build is not
+    # skipped and the repository/ dir is repopulated with the correct release.
+    build_dir_path = example_component_dir(artifacts_dir, "host-fc37", "build")
+    if build_dir_path.exists():
+        shutil.rmtree(build_dir_path)
+    repo_dir_path = artifacts_dir / "repository" / "host-fc37"
+    if repo_dir_path.exists():
+        shutil.rmtree(repo_dir_path)
+
     qb_call(
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "core-qrexec",
+        "example-advanced",
         "-d",
         "host-fc37",
         "package",
         "build",
     )
 
-    build_dir = qrexec_component_dir(artifacts_dir, "host-fc37", "build")
-    repo_dir = qrexec_repo_dir(artifacts_dir, "host-fc37")
+    build_dir = example_component_dir(artifacts_dir, "host-fc37", "build")
+    repo_dir = example_repo_dir(artifacts_dir, "host-fc37")
 
-    with open(build_dir / "rpm_spec_qubes-qrexec.spec.build.yml") as f:
+    with open(build_dir / "rpm_spec_example-dom0.spec.build.yml") as f:
         info = yaml.safe_load(f.read())
 
-    rpms = qrexec_build_rpms()
-    srpm = qrexec_srpm("qubes-core-qrexec")
+    rpms = example_dom0_build_rpms()
+    srpm = example_dom0_srpm()
     for pkg in rpms | {srpm}:
         assert (repo_dir / pkg).exists()
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
     assert info.get("srpm", None) == srpm
 
-    with open(build_dir / "rpm_spec_qubes-qrexec-dom0.spec.build.yml") as f:
+    with open(build_dir / "rpm_spec_example-data.spec.build.yml") as f:
         info = yaml.safe_load(f.read())
 
-    rpms = qrexec_dom0_rpms()
-    srpm = qrexec_srpm("qubes-core-qrexec-dom0")
+    rpms = example_data_build_rpms()
+    srpm = example_data_srpm()
     for pkg in rpms | {srpm}:
         assert (repo_dir / pkg).exists()
     assert set(info.get("rpms", [])) == rpms
     assert HASH_RE.match(info.get("source-hash", None))
     assert info.get("srpm", None) == srpm
-
-    # buildinfo
-    buildinfo = qrexec_rpm("qubes-core-qrexec").replace(".rpm", ".buildinfo")
-    assert (qrexec_component_dir(artifacts_dir, "host-fc37", "build/rpm") / buildinfo).exists()
 
 
 def test_component_host_fc37_sign(artifacts_dir):
     env = os.environ.copy()
-
-    buildinfo = (
-        qrexec_component_dir(artifacts_dir, "host-fc37", "build/rpm")
-        / qrexec_rpm("qubes-core-qrexec").replace(".rpm", ".buildinfo")
-    )
-    buildinfo_number_lines = len(
-        buildinfo.read_text(encoding="utf8").splitlines()
-    )
 
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/gnupg"
@@ -699,7 +658,7 @@ def test_component_host_fc37_sign(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "package",
@@ -710,9 +669,13 @@ def test_component_host_fc37_sign(artifacts_dir):
     dbpath = artifacts_dir / "rpmdb/632F8C69E01B25C9E0C3ADF2F360C0D259FB650C"
     assert dbpath.exists()
 
-    comp_dir = qrexec_component_dir(artifacts_dir, "host-fc37")
-    for rpm in qrexec_all_signed_rpms():
-        rpm_path = comp_dir / ("prep" if rpm.endswith(".src.rpm") else "build/rpm") / rpm
+    comp_dir = example_component_dir(artifacts_dir, "host-fc37")
+    for rpm in example_host_all_signed_rpms():
+        rpm_path = (
+            comp_dir
+            / ("prep" if rpm.endswith(".src.rpm") else "build/rpm")
+            / rpm
+        )
         assert rpm_path.exists()
         result = subprocess.run(
             f"rpm --dbpath {dbpath} -K {rpm_path}",
@@ -722,18 +685,16 @@ def test_component_host_fc37_sign(artifacts_dir):
         )
         assert "digests signatures OK" in result.stdout.decode()
 
-    # Ensure that original content is at least here with the 3 headers PGP BEGIN/END and at least
-    # one line inside the signature
-    buildinfo_content = buildinfo.read_text(encoding="utf8")
-    signed_buildinfo_number_lines = len(buildinfo_content.splitlines())
-
-    assert (signed_buildinfo_number_lines > buildinfo_number_lines + 4) or (
-        "-----BEGIN PGP SIGNED MESSAGE-----" in buildinfo_content
-        and "-----END PGP SIGNATURE-----" in buildinfo_content
-    )
-
 
 def test_component_host_fc37_publish(artifacts_dir):
+    # Clean stale publish state from previous runs to ensure a fresh start.
+    publish_dir = example_component_dir(artifacts_dir, "host-fc37", "publish")
+    if publish_dir.exists():
+        shutil.rmtree(publish_dir)
+    repo_publish_dir = artifacts_dir / "repository-publish"
+    if repo_publish_dir.exists():
+        shutil.rmtree(repo_publish_dir)
+
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/gnupg"
@@ -748,7 +709,7 @@ def test_component_host_fc37_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "repository",
@@ -757,29 +718,31 @@ def test_component_host_fc37_publish(artifacts_dir):
             env=env,
         )
 
-        rpms = qrexec_build_rpms()
-        srpm = qrexec_srpm("qubes-core-qrexec")
-        rpms_dom0 = qrexec_dom0_rpms()
-        srpm_dom0 = qrexec_srpm("qubes-core-qrexec-dom0")
+        rpms_dom0 = example_dom0_build_rpms()
+        srpm_dom0 = example_dom0_srpm()
+        rpms_data = example_data_build_rpms()
+        srpm_data = example_data_srpm()
 
-        publish_dir = qrexec_component_dir(artifacts_dir, "host-fc37", "publish")
-        with open(publish_dir / "rpm_spec_qubes-qrexec.spec.publish.yml") as f:
-            info = yaml.safe_load(f.read())
-        with open(publish_dir / "rpm_spec_qubes-qrexec-dom0.spec.publish.yml") as f:
+        publish_dir = example_component_dir(
+            artifacts_dir, "host-fc37", "publish"
+        )
+        with open(publish_dir / "rpm_spec_example-dom0.spec.publish.yml") as f:
             info_dom0 = yaml.safe_load(f.read())
-
-        assert set(info.get("rpms", [])) == rpms
-        assert info.get("srpm", None) == srpm
-        assert HASH_RE.match(info.get("source-hash", None))
-        assert ["unstable"] == [
-            r["name"] for r in info.get("repository-publish", [])
-        ]
+        with open(publish_dir / "rpm_spec_example-data.spec.publish.yml") as f:
+            info_data = yaml.safe_load(f.read())
 
         assert set(info_dom0.get("rpms", [])) == rpms_dom0
         assert info_dom0.get("srpm", None) == srpm_dom0
         assert HASH_RE.match(info_dom0.get("source-hash", None))
         assert ["unstable"] == [
-            r["name"] for r in info.get("repository-publish", [])
+            r["name"] for r in info_dom0.get("repository-publish", [])
+        ]
+
+        assert set(info_data.get("rpms", [])) == rpms_data
+        assert info_data.get("srpm", None) == srpm_data
+        assert HASH_RE.match(info_data.get("source-hash", None))
+        assert ["unstable"] == [
+            r["name"] for r in info_data.get("repository-publish", [])
         ]
 
         # publish into current-testing
@@ -787,7 +750,7 @@ def test_component_host_fc37_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "repository",
@@ -795,28 +758,25 @@ def test_component_host_fc37_publish(artifacts_dir):
             "current-testing",
             env=env,
         )
-        with open(publish_dir / "rpm_spec_qubes-qrexec.spec.publish.yml") as f:
-            info = yaml.safe_load(f.read())
-        with open(publish_dir / "rpm_spec_qubes-qrexec-dom0.spec.publish.yml") as f:
+        with open(publish_dir / "rpm_spec_example-dom0.spec.publish.yml") as f:
             info_dom0 = yaml.safe_load(f.read())
-
-        assert set(info.get("rpms", [])) == rpms
-        assert info.get("srpm", None) == srpm
-        assert HASH_RE.match(info.get("source-hash", None))
-        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
-            "unstable",
-            "current-testing",
-        }
+        with open(publish_dir / "rpm_spec_example-data.spec.publish.yml") as f:
+            info_data = yaml.safe_load(f.read())
 
         assert set(info_dom0.get("rpms", [])) == rpms_dom0
         assert info_dom0.get("srpm", None) == srpm_dom0
         assert HASH_RE.match(info_dom0.get("source-hash", None))
-        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
-            "unstable",
-            "current-testing",
-        }
+        assert set(
+            [r["name"] for r in info_dom0.get("repository-publish", [])]
+        ) == {"unstable", "current-testing"}
 
-        # buildinfo
+        assert set(info_data.get("rpms", [])) == rpms_data
+        assert info_data.get("srpm", None) == srpm_data
+        assert HASH_RE.match(info_data.get("source-hash", None))
+        assert set(
+            [r["name"] for r in info_data.get("repository-publish", [])]
+        ) == {"unstable", "current-testing"}
+
         assert (
             artifacts_dir
             / "repository-publish/rpm/r4.2/current-testing/host/fc37"
@@ -826,30 +786,32 @@ def test_component_host_fc37_publish(artifacts_dir):
         fake_time = (
             datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=7)
         ).strftime("%Y%m%d%H%M")
-        publish_file = publish_dir / "rpm_spec_qubes-qrexec.spec.publish.yml"
-        publish_dom0_file = publish_dir / "rpm_spec_qubes-qrexec-dom0.spec.publish.yml"
-
-        for r in info["repository-publish"]:
-            if r["name"] == "current-testing":
-                r["timestamp"] = fake_time
-                break
+        publish_dom0_file = (
+            publish_dir / "rpm_spec_example-dom0.spec.publish.yml"
+        )
+        publish_data_file = (
+            publish_dir / "rpm_spec_example-data.spec.publish.yml"
+        )
 
         for r in info_dom0["repository-publish"]:
             if r["name"] == "current-testing":
                 r["timestamp"] = fake_time
                 break
-
-        with open(publish_file, "w") as f:
-            f.write(yaml.safe_dump(info))
+        for r in info_data["repository-publish"]:
+            if r["name"] == "current-testing":
+                r["timestamp"] = fake_time
+                break
 
         with open(publish_dom0_file, "w") as f:
             f.write(yaml.safe_dump(info_dom0))
+        with open(publish_data_file, "w") as f:
+            f.write(yaml.safe_dump(info_data))
 
         qb_call(
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "repository",
@@ -857,33 +819,28 @@ def test_component_host_fc37_publish(artifacts_dir):
             "current",
             env=env,
         )
-        with open(publish_file) as f:
-            info = yaml.safe_load(f.read())
-
         with open(publish_dom0_file) as f:
             info_dom0 = yaml.safe_load(f.read())
-
-        assert set(info.get("rpms", [])) == rpms
-        assert info.get("srpm", None) == srpm
-        assert HASH_RE.match(info.get("source-hash", None))
-        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
-            "unstable",
-            "current-testing",
-            "current",
-        }
+        with open(publish_data_file) as f:
+            info_data = yaml.safe_load(f.read())
 
         assert set(info_dom0.get("rpms", [])) == rpms_dom0
         assert info_dom0.get("srpm", None) == srpm_dom0
         assert HASH_RE.match(info_dom0.get("source-hash", None))
-        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
-            "unstable",
-            "current-testing",
-            "current",
-        }
+        assert set(
+            [r["name"] for r in info_dom0.get("repository-publish", [])]
+        ) == {"unstable", "current-testing", "current"}
+
+        assert set(info_data.get("rpms", [])) == rpms_data
+        assert info_data.get("srpm", None) == srpm_data
+        assert HASH_RE.match(info_data.get("source-hash", None))
+        assert set(
+            [r["name"] for r in info_data.get("repository-publish", [])]
+        ) == {"unstable", "current-testing", "current"}
 
         metadata_dir = (
             artifacts_dir
-            / f"repository-publish/rpm/r4.2/current/host/fc37/repodata"
+            / "repository-publish/rpm/r4.2/current/host/fc37/repodata"
         )
         assert (metadata_dir / "repomd.xml.metalink").exists()
         with open((metadata_dir / "repomd.xml"), "rb") as repomd_f:
@@ -898,23 +855,22 @@ def test_component_host_fc37_publish(artifacts_dir):
             )
         )
 
-        # buildinfo
         assert (
             artifacts_dir / "repository-publish/rpm/r4.2/current/host/fc37"
         ).exists()
 
-    rpms = (
-        qrexec_build_rpms()
-        | {qrexec_srpm("qubes-core-qrexec")}
-        | qrexec_dom0_rpms()
-        | {qrexec_srpm("qubes-core-qrexec-dom0")}
+    all_rpms = (
+        example_dom0_build_rpms()
+        | {example_dom0_srpm()}
+        | example_data_build_rpms()
+        | {example_data_srpm()}
     )
 
     # Check that packages are in the published repository
     for repository in ["unstable", "current-testing", "current"]:
         repository_dir = f"file://{artifacts_dir}/repository-publish/rpm/r4.2/{repository}/host/fc37"
         packages = rpm_packages_list(repository_dir)
-        assert rpms == set(packages)
+        assert all_rpms == set(packages)
 
 
 def test_component_host_fc37_upload(artifacts_dir):
@@ -942,7 +898,7 @@ repository-upload-remote-host:
             builder_conf,
             artifacts_dir,
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "repository",
@@ -952,10 +908,10 @@ repository-upload-remote-host:
         )
 
         all_rpms = (
-            qrexec_build_rpms()
-            | {qrexec_srpm("qubes-core-qrexec")}
-            | qrexec_dom0_rpms()
-            | {qrexec_srpm("qubes-core-qrexec-dom0")}
+            example_dom0_build_rpms()
+            | {example_dom0_srpm()}
+            | example_data_build_rpms()
+            | {example_data_srpm()}
         )
         for rpm in all_rpms:
             assert (
@@ -982,7 +938,7 @@ def test_component_host_fc37_prep_skip(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "core-qrexec",
+        "example-advanced",
         "-d",
         "host-fc37",
         "package",
@@ -990,7 +946,7 @@ def test_component_host_fc37_prep_skip(artifacts_dir):
     ).decode()
     print(result)
     assert (
-        "core-qrexec:host-fedora-37.x86_64: Source hash is the same than already prepared source. Skipping."
+        "example-advanced:host-fedora-37.x86_64: Source hash is the same than already prepared source. Skipping."
         in result
     )
 
@@ -1000,7 +956,7 @@ def test_component_host_fc37_build_skip(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "core-qrexec",
+        "example-advanced",
         "-d",
         "host-fc37",
         "package",
@@ -1008,7 +964,7 @@ def test_component_host_fc37_build_skip(artifacts_dir):
     ).decode()
     print(result)
     assert (
-        "core-qrexec:host-fedora-37.x86_64: Source hash is the same than already built source. Skipping."
+        "example-advanced:host-fedora-37.x86_64: Source hash is the same than already built source. Skipping."
         in result
     )
 
@@ -1027,7 +983,7 @@ def test_component_host_fc37_sign_skip(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "package",
@@ -1035,7 +991,7 @@ def test_component_host_fc37_sign_skip(artifacts_dir):
             env=env,
         ).decode()
 
-    for rpm in qrexec_all_signed_rpms():
+    for rpm in example_host_all_signed_rpms():
         assert f"{rpm} has already a valid signature. Skipping." in result
 
 
@@ -1052,12 +1008,11 @@ def test_component_host_fc37_unpublish(artifacts_dir):
         env["GNUPGHOME"] = gnupghome
         env["HOME"] = tmpdir
 
-        # publish into unstable
         result = qb_call_output(
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "-o",
@@ -1068,41 +1023,39 @@ def test_component_host_fc37_unpublish(artifacts_dir):
             env=env,
         ).decode()
 
-        rpms = qrexec_build_rpms()
-        srpm = qrexec_srpm("qubes-core-qrexec")
-        rpms_dom0 = qrexec_dom0_rpms()
-        srpm_dom0 = qrexec_srpm("qubes-core-qrexec-dom0")
+        rpms_dom0 = example_dom0_build_rpms()
+        srpm_dom0 = example_dom0_srpm()
+        rpms_data = example_data_build_rpms()
+        srpm_data = example_data_srpm()
 
-        publish_dir = qrexec_component_dir(artifacts_dir, "host-fc37", "publish")
-        with open(publish_dir / "rpm_spec_qubes-qrexec.spec.publish.yml") as f:
-            info = yaml.safe_load(f.read())
-        with open(publish_dir / "rpm_spec_qubes-qrexec-dom0.spec.publish.yml") as f:
+        publish_dir = example_component_dir(
+            artifacts_dir, "host-fc37", "publish"
+        )
+        with open(publish_dir / "rpm_spec_example-dom0.spec.publish.yml") as f:
             info_dom0 = yaml.safe_load(f.read())
-
-        assert set(info.get("rpms", [])) == rpms
-        assert info.get("srpm", None) == srpm
-        assert HASH_RE.match(info.get("source-hash", None))
-        assert set([r["name"] for r in info.get("repository-publish", [])]) == {
-            "unstable",
-            "current-testing",
-        }
+        with open(publish_dir / "rpm_spec_example-data.spec.publish.yml") as f:
+            info_data = yaml.safe_load(f.read())
 
         assert set(info_dom0.get("rpms", [])) == rpms_dom0
         assert info_dom0.get("srpm", None) == srpm_dom0
         assert HASH_RE.match(info_dom0.get("source-hash", None))
         assert set(
             [r["name"] for r in info_dom0.get("repository-publish", [])]
-        ) == {
-            "unstable",
-            "current-testing",
-        }
+        ) == {"unstable", "current-testing"}
+
+        assert set(info_data.get("rpms", [])) == rpms_data
+        assert info_data.get("srpm", None) == srpm_data
+        assert HASH_RE.match(info_data.get("source-hash", None))
+        assert set(
+            [r["name"] for r in info_data.get("repository-publish", [])]
+        ) == {"unstable", "current-testing"}
 
     # Check that packages are in the published repository
-    rpms = (
-        qrexec_build_rpms()
-        | {qrexec_srpm("qubes-core-qrexec")}
-        | qrexec_dom0_rpms()
-        | {qrexec_srpm("qubes-core-qrexec-dom0")}
+    all_rpms = (
+        example_dom0_build_rpms()
+        | {example_dom0_srpm()}
+        | example_data_build_rpms()
+        | {example_data_srpm()}
     )
     for repository in ["unstable", "current-testing", "current"]:
         repository_dir = f"file://{artifacts_dir}/repository-publish/rpm/r4.2/{repository}/host/fc37"
@@ -1110,15 +1063,23 @@ def test_component_host_fc37_unpublish(artifacts_dir):
         if repository == "current":
             assert packages == []
         else:
-            assert rpms == set(packages)
+            assert all_rpms == set(packages)
 
-    assert "[qb.publish_rpm.core-qrexec.host-fc37]" in result
+    assert "[qb.publish_rpm.example-advanced.host-fc37]" in result
     assert "[qb.upload.host-fc37]" in result
 
 
 #
-# Pipeline for python-qasync and vm-bookworm
+# Pipeline for example-advanced and vm-bookworm
 #
+
+# DEB version strings for example-advanced on bookworm
+EXAMPLE_DEB_VER = f"{EXAMPLE_VERSION}-1+deb12u1"
+EXAMPLE_DEB_ORIG = f"qubes-example-advanced_{EXAMPLE_VERSION}.orig.tar.gz"
+EXAMPLE_DEB_DEBIAN = f"qubes-example-advanced_{EXAMPLE_DEB_VER}.debian.tar.xz"
+EXAMPLE_DEB_DSC = f"qubes-example-advanced_{EXAMPLE_DEB_VER}.dsc"
+EXAMPLE_PKG_RELEASE_NAME = f"qubes-example-advanced_{EXAMPLE_VERSION}"
+EXAMPLE_PKG_RELEASE_NAME_FULL = f"qubes-example-advanced_{EXAMPLE_DEB_VER}"
 
 
 def test_component_vm_bookworm_init_cache(artifacts_dir):
@@ -1141,7 +1102,7 @@ def test_component_vm_bookworm_prep(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "python-qasync",
+        "example-advanced",
         "-d",
         "vm-bookworm",
         "package",
@@ -1149,31 +1110,31 @@ def test_component_vm_bookworm_prep(artifacts_dir):
         "prep",
     )
 
-    with open(
-        artifacts_dir
-        / "components/python-qasync/0.23.0-2/vm-bookworm/prep/debian-pkg_debian.prep.yml"
-    ) as f:
+    prep_dir = example_component_dir(artifacts_dir, "vm-bookworm", "prep")
+    with open(prep_dir / "debian.prep.yml") as f:
         info = yaml.safe_load(f.read())
 
+    # prep lists all packages including dbgsym variants
     packages = [
-        "python3-qasync_0.23.0-2+deb12u1_all.deb",
-        "python3-qasync-dbgsym_0.23.0-2+deb12u1_all.deb",
-        "python3-qasync-dbgsym_0.23.0-2+deb12u1_all.ddeb",
+        f"qubes-example-advanced_{EXAMPLE_DEB_VER}_all.deb",
+        f"qubes-example-advanced-dbgsym_{EXAMPLE_DEB_VER}_all.deb",
+        f"qubes-example-advanced-dbgsym_{EXAMPLE_DEB_VER}_all.ddeb",
+        f"qubes-example-advanced-libs_{EXAMPLE_DEB_VER}_amd64.deb",
+        f"qubes-example-advanced-libs-dbgsym_{EXAMPLE_DEB_VER}_amd64.deb",
+        f"qubes-example-advanced-libs-dbgsym_{EXAMPLE_DEB_VER}_amd64.ddeb",
+        f"qubes-example-advanced-dev_{EXAMPLE_DEB_VER}_amd64.deb",
+        f"qubes-example-advanced-dev-dbgsym_{EXAMPLE_DEB_VER}_amd64.deb",
+        f"qubes-example-advanced-dev-dbgsym_{EXAMPLE_DEB_VER}_amd64.ddeb",
     ]
-    debian = "python-qasync_0.23.0-2+deb12u1.debian.tar.xz"
-    dsc = "python-qasync_0.23.0-2+deb12u1.dsc"
-    orig = "python-qasync_0.23.0.orig.tar.gz"
-    package_release_name = "python-qasync_0.23.0"
-    package_release_name_full = "python-qasync_0.23.0-2+deb12u1"
-
-    assert info.get("packages", []) == packages
+    assert set(info.get("packages", [])) == set(packages)
     assert HASH_RE.match(info.get("source-hash", None))
-    assert info.get("debian", None) == debian
-    assert info.get("dsc", None) == dsc
-    assert info.get("orig", None) == orig
-    assert info.get("package-release-name", None) == package_release_name
+    assert info.get("debian", None) == EXAMPLE_DEB_DEBIAN
+    assert info.get("dsc", None) == EXAMPLE_DEB_DSC
+    assert info.get("orig", None) == EXAMPLE_DEB_ORIG
+    assert info.get("package-release-name", None) == EXAMPLE_PKG_RELEASE_NAME
     assert (
-        info.get("package-release-name-full", None) == package_release_name_full
+        info.get("package-release-name-full", None)
+        == EXAMPLE_PKG_RELEASE_NAME_FULL
     )
 
 
@@ -1182,46 +1143,41 @@ def test_component_vm_bookworm_build(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "python-qasync",
+        "example-advanced",
         "-d",
         "vm-bookworm",
         "package",
         "build",
     )
 
-    with open(
-        artifacts_dir
-        / "components/python-qasync/0.23.0-2/vm-bookworm/build/debian-pkg_debian.build.yml"
-    ) as f:
+    build_dir = example_component_dir(artifacts_dir, "vm-bookworm", "build")
+    with open(build_dir / "debian.build.yml") as f:
         info = yaml.safe_load(f.read())
 
-    packages = ["python3-qasync_0.23.0-2+deb12u1_all.deb"]
-    debian = "python-qasync_0.23.0-2+deb12u1.debian.tar.xz"
-    dsc = "python-qasync_0.23.0-2+deb12u1.dsc"
-    orig = "python-qasync_0.23.0.orig.tar.gz"
-    package_release_name = "python-qasync_0.23.0"
-    package_release_name_full = "python-qasync_0.23.0-2+deb12u1"
-
-    assert info.get("packages", []) == packages
+    packages = [
+        f"qubes-example-advanced_{EXAMPLE_DEB_VER}_all.deb",
+        f"qubes-example-advanced-libs_{EXAMPLE_DEB_VER}_amd64.deb",
+        f"qubes-example-advanced-libs-dbgsym_{EXAMPLE_DEB_VER}_amd64.deb",
+        f"qubes-example-advanced-dev_{EXAMPLE_DEB_VER}_amd64.deb",
+    ]
+    assert set(info.get("packages", [])) == set(packages)
     assert HASH_RE.match(info.get("source-hash", None))
-    assert info.get("debian", None) == debian
-    assert info.get("dsc", None) == dsc
-    assert info.get("orig", None) == orig
-    assert info.get("package-release-name", None) == package_release_name
+    assert info.get("debian", None) == EXAMPLE_DEB_DEBIAN
+    assert info.get("dsc", None) == EXAMPLE_DEB_DSC
+    assert info.get("orig", None) == EXAMPLE_DEB_ORIG
+    assert info.get("package-release-name", None) == EXAMPLE_PKG_RELEASE_NAME
     assert (
-        info.get("package-release-name-full", None) == package_release_name_full
+        info.get("package-release-name-full", None)
+        == EXAMPLE_PKG_RELEASE_NAME_FULL
     )
 
     files = [
-        "python-qasync_0.23.0-2+deb12u1.dsc",
-        "python-qasync_0.23.0-2+deb12u1_amd64.changes",
-        "python-qasync_0.23.0-2+deb12u1_amd64.buildinfo",
+        EXAMPLE_DEB_DSC,
+        f"qubes-example-advanced_{EXAMPLE_DEB_VER}_amd64.changes",
+        f"qubes-example-advanced_{EXAMPLE_DEB_VER}_amd64.buildinfo",
     ]
     for file in files:
-        file_path = (
-            artifacts_dir
-            / f"components/python-qasync/0.23.0-2/vm-bookworm/build/{file}"
-        )
+        file_path = build_dir / file
         assert file_path.exists()
         result = subprocess.run(
             f"dscverify --no-sig-check {file_path}",
@@ -1244,7 +1200,7 @@ def test_component_vm_bookworm_sign(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "python-qasync",
+            "example-advanced",
             "-d",
             "vm-bookworm",
             "package",
@@ -1252,22 +1208,19 @@ def test_component_vm_bookworm_sign(artifacts_dir):
             env=env,
         )
 
-    keyring_dir = (
-        artifacts_dir
-        / "components/python-qasync/0.23.0-2/vm-bookworm/sign/keyring"
+    keyring_dir = example_component_dir(
+        artifacts_dir, "vm-bookworm", "sign/keyring"
     )
     assert keyring_dir.exists()
 
     files = [
-        "python-qasync_0.23.0-2+deb12u1.dsc",
-        "python-qasync_0.23.0-2+deb12u1_amd64.changes",
-        "python-qasync_0.23.0-2+deb12u1_amd64.buildinfo",
+        EXAMPLE_DEB_DSC,
+        f"qubes-example-advanced_{EXAMPLE_DEB_VER}_amd64.changes",
+        f"qubes-example-advanced_{EXAMPLE_DEB_VER}_amd64.buildinfo",
     ]
+    build_dir = example_component_dir(artifacts_dir, "vm-bookworm", "build")
     for f in files:
-        file_path = (
-            artifacts_dir
-            / f"components/python-qasync/0.23.0-2/vm-bookworm/build/{f}"
-        )
+        file_path = build_dir / f
         assert file_path.exists()
         result = subprocess.run(
             f"gpg2 --homedir {keyring_dir} --verify {file_path}",
@@ -1282,6 +1235,16 @@ def test_component_vm_bookworm_sign(artifacts_dir):
 
 
 def test_component_vm_bookworm_publish(artifacts_dir):
+    # Clean stale publish state from previous runs to ensure a fresh start.
+    stale_publish_dir = example_component_dir(
+        artifacts_dir, "vm-bookworm", "publish"
+    )
+    if stale_publish_dir.exists():
+        shutil.rmtree(stale_publish_dir)
+    stale_deb_repo = artifacts_dir / "repository-publish" / "deb"
+    if stale_deb_repo.exists():
+        shutil.rmtree(stale_deb_repo)
+
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/gnupg"
@@ -1291,12 +1254,17 @@ def test_component_vm_bookworm_publish(artifacts_dir):
         env["GNUPGHOME"] = gnupghome
         env["HOME"] = tmpdir
 
+        publish_dir = example_component_dir(
+            artifacts_dir, "vm-bookworm", "publish"
+        )
+        publish_file = publish_dir / "debian.publish.yml"
+
         # publish into unstable
         qb_call(
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "python-qasync",
+            "example-advanced",
             "-d",
             "vm-bookworm",
             "repository",
@@ -1305,28 +1273,26 @@ def test_component_vm_bookworm_publish(artifacts_dir):
             env=env,
         )
 
-        with open(
-            artifacts_dir
-            / "components/python-qasync/0.23.0-2/vm-bookworm/publish/debian-pkg_debian.publish.yml"
-        ) as f:
+        with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
-        packages = ["python3-qasync_0.23.0-2+deb12u1_all.deb"]
-        debian = "python-qasync_0.23.0-2+deb12u1.debian.tar.xz"
-        dsc = "python-qasync_0.23.0-2+deb12u1.dsc"
-        orig = "python-qasync_0.23.0.orig.tar.gz"
-        package_release_name = "python-qasync_0.23.0"
-        package_release_name_full = "python-qasync_0.23.0-2+deb12u1"
-
-        assert info.get("packages", []) == packages
+        build_packages = [
+            f"qubes-example-advanced_{EXAMPLE_DEB_VER}_all.deb",
+            f"qubes-example-advanced-libs_{EXAMPLE_DEB_VER}_amd64.deb",
+            f"qubes-example-advanced-libs-dbgsym_{EXAMPLE_DEB_VER}_amd64.deb",
+            f"qubes-example-advanced-dev_{EXAMPLE_DEB_VER}_amd64.deb",
+        ]
+        assert set(info.get("packages", [])) == set(build_packages)
         assert HASH_RE.match(info.get("source-hash", None))
-        assert info.get("debian", None) == debian
-        assert info.get("dsc", None) == dsc
-        assert info.get("orig", None) == orig
-        assert info.get("package-release-name", None) == package_release_name
+        assert info.get("debian", None) == EXAMPLE_DEB_DEBIAN
+        assert info.get("dsc", None) == EXAMPLE_DEB_DSC
+        assert info.get("orig", None) == EXAMPLE_DEB_ORIG
+        assert (
+            info.get("package-release-name", None) == EXAMPLE_PKG_RELEASE_NAME
+        )
         assert (
             info.get("package-release-name-full", None)
-            == package_release_name_full
+            == EXAMPLE_PKG_RELEASE_NAME_FULL
         )
         assert ["unstable"] == [
             r["name"] for r in info.get("repository-publish", [])
@@ -1337,7 +1303,7 @@ def test_component_vm_bookworm_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "python-qasync",
+            "example-advanced",
             "-d",
             "vm-bookworm",
             "repository",
@@ -1345,22 +1311,11 @@ def test_component_vm_bookworm_publish(artifacts_dir):
             "current-testing",
             env=env,
         )
-        with open(
-            artifacts_dir
-            / "components/python-qasync/0.23.0-2/vm-bookworm/publish/debian-pkg_debian.publish.yml"
-        ) as f:
+        with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
-        assert info.get("packages", []) == packages
+        assert set(info.get("packages", [])) == set(build_packages)
         assert HASH_RE.match(info.get("source-hash", None))
-        assert info.get("debian", None) == debian
-        assert info.get("dsc", None) == dsc
-        assert info.get("orig", None) == orig
-        assert info.get("package-release-name", None) == package_release_name
-        assert (
-            info.get("package-release-name-full", None)
-            == package_release_name_full
-        )
         assert set([r["name"] for r in info.get("repository-publish", [])]) == {
             "unstable",
             "current-testing",
@@ -1370,10 +1325,6 @@ def test_component_vm_bookworm_publish(artifacts_dir):
         fake_time = (
             datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=7)
         ).strftime("%Y%m%d%H%M")
-        publish_file = (
-            artifacts_dir
-            / "components/python-qasync/0.23.0-2/vm-bookworm/publish/debian-pkg_debian.publish.yml"
-        )
 
         for r in info["repository-publish"]:
             if r["name"] == "current-testing":
@@ -1387,7 +1338,7 @@ def test_component_vm_bookworm_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "python-qasync",
+            "example-advanced",
             "-d",
             "vm-bookworm",
             "repository",
@@ -1398,16 +1349,8 @@ def test_component_vm_bookworm_publish(artifacts_dir):
         with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
-        assert info.get("packages", []) == packages
+        assert set(info.get("packages", [])) == set(build_packages)
         assert HASH_RE.match(info.get("source-hash", None))
-        assert info.get("debian", None) == debian
-        assert info.get("dsc", None) == dsc
-        assert info.get("orig", None) == orig
-        assert info.get("package-release-name", None) == package_release_name
-        assert (
-            info.get("package-release-name-full", None)
-            == package_release_name_full
-        )
         assert set([r["name"] for r in info.get("repository-publish", [])]) == {
             "unstable",
             "current-testing",
@@ -1419,8 +1362,11 @@ def test_component_vm_bookworm_publish(artifacts_dir):
     for codename in ["bookworm-unstable", "bookworm-testing", "bookworm"]:
         packages = deb_packages_list(repository_dir, codename)
         expected_packages = [
-            f"{codename}|main|amd64: python3-qasync 0.23.0-2+deb12u1",
-            f"{codename}|main|source: python-qasync 0.23.0-2+deb12u1",
+            f"{codename}|main|amd64: qubes-example-advanced {EXAMPLE_DEB_VER}",
+            f"{codename}|main|amd64: qubes-example-advanced-libs {EXAMPLE_DEB_VER}",
+            f"{codename}|main|amd64: qubes-example-advanced-libs-dbgsym {EXAMPLE_DEB_VER}",
+            f"{codename}|main|amd64: qubes-example-advanced-dev {EXAMPLE_DEB_VER}",
+            f"{codename}|main|source: qubes-example-advanced {EXAMPLE_DEB_VER}",
         ]
         assert set(packages) == set(expected_packages)
         # verify if repository is signed
@@ -1436,7 +1382,7 @@ def test_component_vm_bookworm_prep_skip(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "python-qasync",
+        "example-advanced",
         "-d",
         "vm-bookworm",
         "package",
@@ -1444,7 +1390,7 @@ def test_component_vm_bookworm_prep_skip(artifacts_dir):
     ).decode()
     print(result)
     assert (
-        "python-qasync:vm-debian-12.amd64: Source hash is the same than already prepared source. Skipping."
+        "example-advanced:vm-debian-12.amd64: Source hash is the same than already prepared source. Skipping."
         in result
     )
 
@@ -1454,7 +1400,7 @@ def test_component_vm_bookworm_build_skip(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "python-qasync",
+        "example-advanced",
         "-d",
         "vm-bookworm",
         "package",
@@ -1462,7 +1408,7 @@ def test_component_vm_bookworm_build_skip(artifacts_dir):
     ).decode()
     print(result)
     assert (
-        "python-qasync:vm-debian-12.amd64: Source hash is the same than already built source. Skipping."
+        "example-advanced:vm-debian-12.amd64: Source hash is the same than already built source. Skipping."
         in result
     )
 
@@ -1481,7 +1427,7 @@ def test_component_vm_bookworm_sign_skip(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "python-qasync",
+            "example-advanced",
             "-d",
             "vm-bookworm",
             "package",
@@ -1489,7 +1435,7 @@ def test_component_vm_bookworm_sign_skip(artifacts_dir):
             env=env,
         ).decode()
 
-    assert f"Leaving current signature unchanged." in result
+    assert "Leaving current signature unchanged." in result
 
 
 # Check that we unpublish properly from current-testing
@@ -1501,8 +1447,11 @@ def test_component_vm_bookworm_unpublish(artifacts_dir):
     for codename in ["bookworm-unstable", "bookworm-testing", "bookworm"]:
         packages = deb_packages_list(repository_dir, codename)
         expected_packages = [
-            f"{codename}|main|amd64: python3-qasync 0.23.0-2+deb12u1",
-            f"{codename}|main|source: python-qasync 0.23.0-2+deb12u1",
+            f"{codename}|main|amd64: qubes-example-advanced {EXAMPLE_DEB_VER}",
+            f"{codename}|main|amd64: qubes-example-advanced-libs {EXAMPLE_DEB_VER}",
+            f"{codename}|main|amd64: qubes-example-advanced-libs-dbgsym {EXAMPLE_DEB_VER}",
+            f"{codename}|main|amd64: qubes-example-advanced-dev {EXAMPLE_DEB_VER}",
+            f"{codename}|main|source: qubes-example-advanced {EXAMPLE_DEB_VER}",
         ]
         assert set(packages) == set(expected_packages)
 
@@ -1515,12 +1464,11 @@ def test_component_vm_bookworm_unpublish(artifacts_dir):
         env["GNUPGHOME"] = gnupghome
         env["HOME"] = tmpdir
 
-        # publish into unstable
         qb_call(
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "python-qasync",
+            "example-advanced",
             "-d",
             "vm-bookworm",
             "repository",
@@ -1529,54 +1477,44 @@ def test_component_vm_bookworm_unpublish(artifacts_dir):
             env=env,
         )
 
-        packages = ["python3-qasync_0.23.0-2+deb12u1_all.deb"]
-        debian = "python-qasync_0.23.0-2+deb12u1.debian.tar.xz"
-        dsc = "python-qasync_0.23.0-2+deb12u1.dsc"
-        orig = "python-qasync_0.23.0.orig.tar.gz"
-        package_release_name = "python-qasync_0.23.0"
-        package_release_name_full = "python-qasync_0.23.0-2+deb12u1"
-
-        with open(
-            artifacts_dir
-            / "components/python-qasync/0.23.0-2/vm-bookworm/publish/debian-pkg_debian.publish.yml"
-        ) as f:
+        publish_dir = example_component_dir(
+            artifacts_dir, "vm-bookworm", "publish"
+        )
+        with open(publish_dir / "debian.publish.yml") as f:
             info = yaml.safe_load(f.read())
 
-        assert info.get("packages", []) == packages
-        assert HASH_RE.match(info.get("source-hash", None))
-        assert info.get("debian", None) == debian
-        assert info.get("dsc", None) == dsc
-        assert info.get("orig", None) == orig
-        assert info.get("package-release-name", None) == package_release_name
-        assert (
-            info.get("package-release-name-full", None)
-            == package_release_name_full
-        )
         assert set([r["name"] for r in info.get("repository-publish", [])]) == {
             "unstable",
             "current-testing",
         }
 
     # Check that packages are in the published repositories
-    repository_dir = artifacts_dir / "repository-publish/deb/r4.2/vm"
     for codename in ["bookworm-unstable", "bookworm-testing", "bookworm"]:
         packages = deb_packages_list(repository_dir, codename)
         if codename == "bookworm":
             expected_packages = []
         else:
             expected_packages = [
-                f"{codename}|main|amd64: python3-qasync 0.23.0-2+deb12u1",
-                f"{codename}|main|source: python-qasync 0.23.0-2+deb12u1",
+                f"{codename}|main|amd64: qubes-example-advanced {EXAMPLE_DEB_VER}",
+                f"{codename}|main|amd64: qubes-example-advanced-libs {EXAMPLE_DEB_VER}",
+                f"{codename}|main|amd64: qubes-example-advanced-libs-dbgsym {EXAMPLE_DEB_VER}",
+                f"{codename}|main|amd64: qubes-example-advanced-dev {EXAMPLE_DEB_VER}",
+                f"{codename}|main|source: qubes-example-advanced {EXAMPLE_DEB_VER}",
             ]
         assert set(packages) == set(expected_packages)
 
 
 def test_increment_component_fetch(artifacts_dir):
-    # # clean
-    # for d in ["sources", "components", "repository", "repository-publish", "tmp"]:
-    #     if not (artifacts_dir / d).exists():
-    #         continue
-    #     shutil.rmtree(artifacts_dir / d)
+    # Reset devel counters so the test is idempotent across runs.
+    devel_file = (
+        artifacts_dir
+        / "components"
+        / "example-advanced"
+        / "noversion"
+        / "devel"
+    )
+    if devel_file.exists():
+        devel_file.unlink()
 
     qb_call(
         DEFAULT_BUILDER_CONF,
@@ -1587,19 +1525,17 @@ def test_increment_component_fetch(artifacts_dir):
         "fetch",
     )
 
-    for component in [
-        "core-qrexec",
-        "core-vchan-xen",
-        "desktop-linux-xfce4-xfwm4",
-        "python-qasync",
-    ]:
-        assert (
-            artifacts_dir / "components" / component / "noversion" / "devel"
-        ).exists()
+    assert (
+        artifacts_dir
+        / "components"
+        / "example-advanced"
+        / "noversion"
+        / "devel"
+    ).exists()
 
-        (artifacts_dir / "sources" / component / "hello").write_text(
-            "world", encoding="utf8"
-        )
+    (artifacts_dir / "sources" / "example-advanced" / "hello").write_text(
+        "world", encoding="utf8"
+    )
 
     qb_call(
         DEFAULT_BUILDER_CONF,
@@ -1610,15 +1546,13 @@ def test_increment_component_fetch(artifacts_dir):
         "fetch",
     )
 
-    for component in [
-        "core-qrexec",
-        "core-vchan-xen",
-        "desktop-linux-xfce4-xfwm4",
-        "python-qasync",
-    ]:
-        assert (
-            artifacts_dir / "components" / component / "noversion" / "devel"
-        ).read_text(encoding="utf-8") == "2"
+    assert (
+        artifacts_dir
+        / "components"
+        / "example-advanced"
+        / "noversion"
+        / "devel"
+    ).read_text(encoding="utf-8") == "2"
 
 
 def test_increment_component_build(artifacts_dir):
@@ -1633,8 +1567,9 @@ def test_increment_component_build(artifacts_dir):
 
         devel_path = (
             pathlib.Path(artifacts_dir)
-            / "components/core-qrexec/noversion/devel"
+            / "components/example-advanced/noversion/devel"
         )
+        devel_path.parent.mkdir(parents=True, exist_ok=True)
         devel_path.write_text("41", encoding="utf-8")
 
         qb_call(
@@ -1647,7 +1582,7 @@ def test_increment_component_build(artifacts_dir):
         )
 
         assert (
-            artifacts_dir / "components/core-qrexec/noversion/devel"
+            artifacts_dir / "components/example-advanced/noversion/devel"
         ).read_text(encoding="utf-8") == "42"
 
         qb_call(
@@ -1656,7 +1591,7 @@ def test_increment_component_build(artifacts_dir):
             "--option",
             "increment-devel-versions=true",
             "-c",
-            "core-qrexec",
+            "example-advanced",
             "-d",
             "host-fc37",
             "-d",
@@ -1666,33 +1601,178 @@ def test_increment_component_build(artifacts_dir):
             env=env,
         )
 
-    repo_dir = qrexec_repo_dir(artifacts_dir, "host-fc37")
-    for pkg in qrexec_build_rpms(devel=42) | {qrexec_srpm("qubes-core-qrexec", devel=42)}:
+    repo_dir = example_repo_dir(artifacts_dir, "host-fc37")
+    for pkg in example_dom0_build_rpms(devel=42) | {
+        example_dom0_srpm(devel=42)
+    }:
         assert (repo_dir / pkg).exists()
-    for pkg in qrexec_dom0_rpms(devel=42) | {qrexec_srpm("qubes-core-qrexec-dom0", devel=42)}:
+    for pkg in example_data_build_rpms(devel=42) | {
+        example_data_srpm(devel=42)
+    }:
         assert (repo_dir / pkg).exists()
 
+    deb_ver = f"{EXAMPLE_VERSION}-1+deb12u1+devel42"
     deb_files = [
-        qrexec_deb("libqrexec-utils-dev", devel=42),
-        qrexec_deb("libqrexec-utils2-dbgsym", devel=42),
-        qrexec_deb("libqrexec-utils2", devel=42),
-        qrexec_deb("python3-qrexec", devel=42),
-        qrexec_deb("qubes-core-qrexec-dbgsym", devel=42),
-        qrexec_deb("qubes-core-qrexec", devel=42, ext="debian.tar.xz"),
-        qrexec_deb("qubes-core-qrexec", devel=42, ext="dsc"),
-        qrexec_deb("qubes-core-qrexec", devel=42, ext="buildinfo"),
-        qrexec_deb("qubes-core-qrexec", devel=42, ext="changes"),
-        qrexec_deb("qubes-core-qrexec", devel=42),
-        qrexec_deb("qubes-core-qrexec", ext="orig"),
+        f"qubes-example-advanced_{deb_ver}_all.deb",
+        f"qubes-example-advanced-libs_{deb_ver}_amd64.deb",
+        f"qubes-example-advanced-dev_{deb_ver}_amd64.deb",
+        f"qubes-example-advanced_{deb_ver}.debian.tar.xz",
+        f"qubes-example-advanced_{deb_ver}.dsc",
+        f"qubes-example-advanced_{deb_ver}_amd64.buildinfo",
+        f"qubes-example-advanced_{deb_ver}_amd64.changes",
+        f"qubes-example-advanced_{EXAMPLE_VERSION}.orig.tar.gz",
     ]
-    repo_deb_dir = qrexec_repo_dir(artifacts_dir, "vm-bookworm")
+    repo_deb_dir = example_repo_dir(artifacts_dir, "vm-bookworm")
     for file in deb_files:
         assert (repo_deb_dir / file).exists()
 
 
+def test_publish_deb_no_source_conflict(artifacts_dir_single):
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        # First build cycle (devel=1): fetch, prep, build, sign
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-trixie",
+            "package",
+            "fetch",
+            "prep",
+            "build",
+            "sign",
+            env=env,
+        )
+
+        assert (
+            artifacts_dir_single / "components/example-advanced/noversion/devel"
+        ).read_text(encoding="utf-8") == "1"
+
+        # Publish devel=1 to current-testing: registers orig.tar.gz (checksum A)
+        # in the reprepro pool alongside the binary and source packages.
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-trixie",
+            "repository",
+            "publish",
+            "current-testing",
+            env=env,
+        )
+
+        repository_dir = artifacts_dir_single / "repository-publish/deb/r4.2/vm"
+        packages = deb_packages_list(repository_dir, "trixie-testing")
+        assert any(
+            "qubes-example-advanced" in p and "devel1" in p for p in packages
+        )
+        assert any(
+            "|main|source: qubes-example-advanced" in p for p in packages
+        )
+
+        # Modify the upstream source so the rebuilt orig.tar.gz has a different
+        # checksum than the one already in the reprepro pool.
+        (artifacts_dir_single / "sources/example-advanced/hello").write_text(
+            "world", encoding="utf8"
+        )
+
+        # Second fetch increments devel from 1 to 2.
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-trixie",
+            "package",
+            "fetch",
+            env=env,
+        )
+
+        assert (
+            artifacts_dir_single / "components/example-advanced/noversion/devel"
+        ).read_text(encoding="utf-8") == "2"
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-trixie",
+            "package",
+            "prep",
+            "build",
+            "sign",
+            env=env,
+        )
+
+        # Publish devel=2 to unstable.  The publish detects the source-hash
+        # change in history, unpublishes devel=1 from current-testing (with
+        # --delete so the stale orig.tar.gz is removed from the pool), then
+        # publishes the full .changes for devel=2 including the updated orig.tar.gz.
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-trixie",
+            "repository",
+            "publish",
+            "unstable",
+            env=env,
+        )
+
+        packages = deb_packages_list(repository_dir, "trixie-unstable")
+        assert any(
+            "qubes-example-advanced" in p and "devel2" in p for p in packages
+        )
+        assert any(
+            "|main|source: qubes-example-advanced" in p for p in packages
+        )
+
+        # The stale devel=1 publication must have been cleaned from current-testing
+        # (its orig.tar.gz removed from the pool) before devel=2 could be published.
+        packages_testing = deb_packages_list(repository_dir, "trixie-testing")
+        assert not any(
+            "qubes-example-advanced" in p and "devel1" in p
+            for p in packages_testing
+        )
+        assert not any(
+            "|main|source: qubes-example-advanced" in p and "devel1" in p
+            for p in packages_testing
+        )
+
+
 #
-# Pipeline for app-linux-split-gpg and vm-archlinux
+# Pipeline for example-advanced and vm-archlinux
 #
+
+EXAMPLE_ARCH_PKG = f"qubes-example-advanced-{EXAMPLE_VERSION}-{EXAMPLE_RELEASE}-x86_64.pkg.tar.zst"
+EXAMPLE_ARCH_ARCHIVE = (
+    f"qubes-example-advanced-{EXAMPLE_VERSION}-{EXAMPLE_RELEASE}.tar.gz"
+)
 
 
 def test_component_vm_archlinux_init_cache(artifacts_dir):
@@ -1715,7 +1795,7 @@ def test_component_vm_archlinux_prep(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "app-linux-split-gpg",
+        "example-advanced",
         "-d",
         "vm-archlinux",
         "package",
@@ -1723,16 +1803,12 @@ def test_component_vm_archlinux_prep(artifacts_dir):
         "prep",
     )
 
-    with open(
-        artifacts_dir
-        / "components/app-linux-split-gpg/2.0.67-1/vm-archlinux/prep/archlinux.prep.yml"
-    ) as f:
+    prep_dir = example_component_dir(artifacts_dir, "vm-archlinux", "prep")
+    with open(prep_dir / "archlinux.prep.yml") as f:
         info = yaml.safe_load(f.read())
 
-    assert info.get("packages", []) == [
-        "qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
-    ]
-    assert info.get("source-archive", None) == "qubes-gpg-split-2.0.67-1.tar.gz"
+    assert EXAMPLE_ARCH_PKG in info.get("packages", [])
+    assert info.get("source-archive", None) == EXAMPLE_ARCH_ARCHIVE
     assert HASH_RE.match(info.get("source-hash", None))
 
 
@@ -1741,29 +1817,22 @@ def test_component_vm_archlinux_build(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "app-linux-split-gpg",
+        "example-advanced",
         "-d",
         "vm-archlinux",
         "package",
         "build",
     )
 
-    with open(
-        artifacts_dir
-        / "components/app-linux-split-gpg/2.0.67-1/vm-archlinux/build/archlinux.build.yml"
-    ) as f:
+    build_dir = example_component_dir(artifacts_dir, "vm-archlinux", "build")
+    with open(build_dir / "archlinux.build.yml") as f:
         info = yaml.safe_load(f.read())
 
-    assert info.get("packages", []) == [
-        "qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
-    ]
-    assert info.get("source-archive", None) == "qubes-gpg-split-2.0.67-1.tar.gz"
+    assert EXAMPLE_ARCH_PKG in info.get("packages", [])
+    assert info.get("source-archive", None) == EXAMPLE_ARCH_ARCHIVE
     assert HASH_RE.match(info.get("source-hash", None))
 
-    pkg_path = (
-        artifacts_dir
-        / f"components/app-linux-split-gpg/2.0.67-1/vm-archlinux/build/pkgs/qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
-    )
+    pkg_path = build_dir / "pkgs" / EXAMPLE_ARCH_PKG
     assert pkg_path.exists()
 
 
@@ -1772,20 +1841,16 @@ def test_component_vm_archlinux_sign(artifacts_dir):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/gnupg"
-        # Better copy testing keyring into a separate directory to prevent locks inside
-        # local sources (when executed locally).
         shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
         os.chmod(gnupghome, 0o700)
-        # Enforce keyring location
         env["GNUPGHOME"] = gnupghome
-        # We prevent rpm to find ~/.rpmmacros
         env["HOME"] = tmpdir
 
         qb_call(
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "app-linux-split-gpg",
+            "example-advanced",
             "-d",
             "vm-archlinux",
             "package",
@@ -1793,13 +1858,11 @@ def test_component_vm_archlinux_sign(artifacts_dir):
             env=env,
         )
         pkgs_dir = (
-            artifacts_dir
-            / "components/app-linux-split-gpg/2.0.67-1/vm-archlinux/build/pkgs"
+            example_component_dir(artifacts_dir, "vm-archlinux", "build")
+            / "pkgs"
         )
-        pkg_path = pkgs_dir / "qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
-        pkg_sig_path = (
-            pkgs_dir / "qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst.sig"
-        )
+        pkg_path = pkgs_dir / EXAMPLE_ARCH_PKG
+        pkg_sig_path = pkgs_dir / (EXAMPLE_ARCH_PKG + ".sig")
         assert pkg_path.exists()
         assert pkg_sig_path.exists()
 
@@ -1813,6 +1876,16 @@ def test_component_vm_archlinux_sign(artifacts_dir):
 
 
 def test_component_vm_archlinux_publish(artifacts_dir):
+    # Clean stale publish state from previous runs to ensure a fresh start.
+    stale_publish_dir = example_component_dir(
+        artifacts_dir, "vm-archlinux", "publish"
+    )
+    if stale_publish_dir.exists():
+        shutil.rmtree(stale_publish_dir)
+    stale_arch_repo = artifacts_dir / "repository-publish" / "archlinux"
+    if stale_arch_repo.exists():
+        shutil.rmtree(stale_arch_repo)
+
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/gnupg"
@@ -1822,12 +1895,17 @@ def test_component_vm_archlinux_publish(artifacts_dir):
         env["GNUPGHOME"] = gnupghome
         env["HOME"] = tmpdir
 
+        publish_dir = example_component_dir(
+            artifacts_dir, "vm-archlinux", "publish"
+        )
+        publish_file = publish_dir / "archlinux.publish.yml"
+
         # publish into unstable
         qb_call(
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "app-linux-split-gpg",
+            "example-advanced",
             "-d",
             "vm-archlinux",
             "repository",
@@ -1836,15 +1914,10 @@ def test_component_vm_archlinux_publish(artifacts_dir):
             env=env,
         )
 
-        with open(
-            artifacts_dir
-            / "components/app-linux-split-gpg/2.0.67-1/vm-archlinux/publish/archlinux.publish.yml"
-        ) as f:
+        with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
-        assert info.get("packages", []) == [
-            "qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
-        ]
+        assert EXAMPLE_ARCH_PKG in info.get("packages", [])
         assert HASH_RE.match(info.get("source-hash", None))
         assert ["unstable"] == [
             r["name"] for r in info.get("repository-publish", [])
@@ -1855,7 +1928,7 @@ def test_component_vm_archlinux_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "app-linux-split-gpg",
+            "example-advanced",
             "-d",
             "vm-archlinux",
             "repository",
@@ -1863,15 +1936,10 @@ def test_component_vm_archlinux_publish(artifacts_dir):
             "current-testing",
             env=env,
         )
-        with open(
-            artifacts_dir
-            / "components/app-linux-split-gpg/2.0.67-1/vm-archlinux/publish/archlinux.publish.yml"
-        ) as f:
+        with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
-        assert info.get("packages", []) == [
-            "qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
-        ]
+        assert EXAMPLE_ARCH_PKG in info.get("packages", [])
         assert HASH_RE.match(info.get("source-hash", None))
         assert set([r["name"] for r in info.get("repository-publish", [])]) == {
             "unstable",
@@ -1882,10 +1950,6 @@ def test_component_vm_archlinux_publish(artifacts_dir):
         fake_time = (
             datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=7)
         ).strftime("%Y%m%d%H%M")
-        publish_file = (
-            artifacts_dir
-            / "components/app-linux-split-gpg/2.0.67-1/vm-archlinux/publish/archlinux.publish.yml"
-        )
 
         for r in info["repository-publish"]:
             if r["name"] == "current-testing":
@@ -1899,7 +1963,7 @@ def test_component_vm_archlinux_publish(artifacts_dir):
             DEFAULT_BUILDER_CONF,
             artifacts_dir,
             "-c",
-            "app-linux-split-gpg",
+            "example-advanced",
             "-d",
             "vm-archlinux",
             "repository",
@@ -1910,9 +1974,7 @@ def test_component_vm_archlinux_publish(artifacts_dir):
         with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
-        assert info.get("packages", []) == [
-            "qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
-        ]
+        assert EXAMPLE_ARCH_PKG in info.get("packages", [])
         assert HASH_RE.match(info.get("source-hash", None))
         assert set([r["name"] for r in info.get("repository-publish", [])]) == {
             "unstable",
@@ -1922,13 +1984,13 @@ def test_component_vm_archlinux_publish(artifacts_dir):
 
         qubesdb = (
             artifacts_dir
-            / f"repository-publish/archlinux/r4.2/current/vm/archlinux/pkgs/qubes-r4.2-current.db.tar.gz"
+            / "repository-publish/archlinux/r4.2/current/vm/archlinux/pkgs/qubes-r4.2-current.db.tar.gz"
         )
         assert qubesdb.exists()
 
         qubesdb_sig = (
             artifacts_dir
-            / f"repository-publish/archlinux/r4.2/current/vm/archlinux/pkgs/qubes-r4.2-current.db.tar.gz.sig"
+            / "repository-publish/archlinux/r4.2/current/vm/archlinux/pkgs/qubes-r4.2-current.db.tar.gz.sig"
         )
         assert qubesdb_sig.exists()
 
@@ -1959,7 +2021,7 @@ repository-upload-remote-host:
             builder_conf,
             artifacts_dir,
             "-c",
-            "app-linux-split-gpg",
+            "example-advanced",
             "-d",
             "vm-archlinux",
             "repository",
@@ -1970,33 +2032,125 @@ repository-upload-remote-host:
 
         assert (
             pathlib.Path(tmpdir)
-            / f"repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst"
+            / f"repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/{EXAMPLE_ARCH_PKG}"
         ).exists()
 
         assert (
             pathlib.Path(tmpdir)
-            / f"repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/qubes-gpg-split-2.0.67-1-x86_64.pkg.tar.zst.sig"
+            / f"repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/{EXAMPLE_ARCH_PKG}.sig"
         ).exists()
 
         assert (
             pathlib.Path(tmpdir)
-            / f"repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/qubes-r4.2-unstable.db.tar.gz"
+            / "repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/qubes-r4.2-unstable.db.tar.gz"
         ).exists()
 
         assert (
             pathlib.Path(tmpdir)
-            / f"repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/qubes-r4.2-unstable.db.tar.gz.sig"
+            / "repo/archlinux/r4.2/unstable/vm/archlinux/pkgs/qubes-r4.2-unstable.db.tar.gz.sig"
         ).exists()
 
         # vm-fc43 shouldn't exist, as nothing was published into it
         assert not (
-            pathlib.Path(tmpdir) / f"repo/rpm/r4.2/unstable/vm/fc43"
+            pathlib.Path(tmpdir) / "repo/rpm/r4.2/unstable/vm/fc43"
         ).exists()
 
         # and vm-bookworm same
         assert not (
-            pathlib.Path(tmpdir) / f"repo/deb/r4.2/vm/dists/bookworm-unstable"
+            pathlib.Path(tmpdir) / "repo/deb/r4.2/vm/dists/bookworm-unstable"
         ).exists()
+
+
+#
+# Pipeline for components using source:files: without create-archive.
+# Validates that the external file is used as the .orig.tar.gz for deb builds.
+# Add entries here to cover additional components with the same feature.
+#
+
+FILES_ONLY_COMPONENTS = [
+    pytest.param(
+        {
+            "component": "python-qasync",
+            "version": QASYNC_VERSION,
+            "release": QASYNC_RELEASE,
+            "prep_yml": "debian-pkg_debian.prep.yml",
+            "build_yml": "debian-pkg_debian.build.yml",
+            "orig": QASYNC_ORIG,
+            "dsc": QASYNC_DSC,
+            "debian": QASYNC_DEBIAN,
+            "package": f"python3-qasync_{QASYNC_DEB_VER}_all.deb",
+        },
+        id="python-qasync",
+    ),
+]
+
+
+def files_only_component_dir(
+    artifacts_dir, component, version, release, dist, stage=None
+):
+    base = artifacts_dir / f"components/{component}/{version}-{release}/{dist}"
+    return base / stage if stage else base
+
+
+@pytest.mark.parametrize("cfg", FILES_ONLY_COMPONENTS)
+def test_component_vm_bookworm_files_only_prep(artifacts_dir, cfg):
+    qb_call(
+        DEFAULT_BUILDER_CONF,
+        artifacts_dir,
+        "-c",
+        cfg["component"],
+        "-d",
+        "vm-bookworm",
+        "package",
+        "fetch",
+        "prep",
+    )
+
+    prep_dir = files_only_component_dir(
+        artifacts_dir,
+        cfg["component"],
+        cfg["version"],
+        cfg["release"],
+        "vm-bookworm",
+        "prep",
+    )
+    with open(prep_dir / cfg["prep_yml"]) as f:
+        info = yaml.safe_load(f.read())
+
+    # The .orig.tar.gz must be the external file, not a component archive.
+    assert info.get("orig", None) == cfg["orig"]
+    assert info.get("dsc", None) == cfg["dsc"]
+    assert info.get("debian", None) == cfg["debian"]
+    assert HASH_RE.match(info.get("source-hash", ""))
+    assert cfg["package"] in info.get("packages", [])
+
+
+@pytest.mark.parametrize("cfg", FILES_ONLY_COMPONENTS)
+def test_component_vm_bookworm_files_only_build(artifacts_dir, cfg):
+    qb_call(
+        DEFAULT_BUILDER_CONF,
+        artifacts_dir,
+        "-c",
+        cfg["component"],
+        "-d",
+        "vm-bookworm",
+        "package",
+        "build",
+    )
+
+    build_dir = files_only_component_dir(
+        artifacts_dir,
+        cfg["component"],
+        cfg["version"],
+        cfg["release"],
+        "vm-bookworm",
+        "build",
+    )
+    with open(build_dir / cfg["build_yml"]) as f:
+        info = yaml.safe_load(f.read())
+
+    assert info.get("orig", None) == cfg["orig"]
+    assert cfg["package"] in info.get("packages", [])
 
 
 def _get_template_timestamp(artifacts_dir, template_name, stage):
@@ -2038,7 +2192,9 @@ def test_template_fedora_43_minimal_prep(artifacts_dir):
         artifacts_dir / f"templates/qubeized_images/{FEDORA_MINIMAL}/root.img"
     ).exists()
     assert (artifacts_dir / f"templates/{FEDORA_MINIMAL}/appmenus").exists()
-    assert (artifacts_dir / f"templates/{FEDORA_MINIMAL}/template.conf").exists()
+    assert (
+        artifacts_dir / f"templates/{FEDORA_MINIMAL}/template.conf"
+    ).exists()
 
 
 def test_template_fedora_43_minimal_build(artifacts_dir):
@@ -2051,8 +2207,12 @@ def test_template_fedora_43_minimal_build(artifacts_dir):
         "build",
     )
 
-    template_prep_timestamp = _get_template_timestamp(artifacts_dir, FEDORA_MINIMAL, "prep")
-    template_timestamp = _get_template_timestamp(artifacts_dir, FEDORA_MINIMAL, "build")
+    template_prep_timestamp = _get_template_timestamp(
+        artifacts_dir, FEDORA_MINIMAL, "prep"
+    )
+    template_timestamp = _get_template_timestamp(
+        artifacts_dir, FEDORA_MINIMAL, "build"
+    )
     assert template_timestamp == template_prep_timestamp
 
     assert (
@@ -2087,7 +2247,9 @@ def test_template_fedora_43_minimal_sign(artifacts_dir):
     dbpath = artifacts_dir / "templates/rpmdb"
     assert dbpath.exists()
 
-    template_timestamp = _get_template_timestamp(artifacts_dir, FEDORA_MINIMAL, "build")
+    template_timestamp = _get_template_timestamp(
+        artifacts_dir, FEDORA_MINIMAL, "build"
+    )
     rpm_path = (
         artifacts_dir
         / f"templates/rpm/qubes-template-{FEDORA_MINIMAL}-4.2.0-{template_timestamp}.noarch.rpm"
@@ -2103,6 +2265,16 @@ def test_template_fedora_43_minimal_sign(artifacts_dir):
 
 
 def test_template_fedora_43_minimal_publish(artifacts_dir):
+    # Clean stale publish state from previous runs.
+    stale_publish = artifacts_dir / f"templates/{FEDORA_MINIMAL}.publish.yml"
+    if stale_publish.exists():
+        stale_publish.unlink()
+    stale_rpm_repo = artifacts_dir / "repository-publish/rpm/r4.2"
+    for repo in ("templates-itl-testing", "templates-itl"):
+        stale = stale_rpm_repo / repo
+        if stale.exists():
+            shutil.rmtree(stale)
+
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/gnupg"
@@ -2128,7 +2300,9 @@ def test_template_fedora_43_minimal_publish(artifacts_dir):
         with open(publish_file) as f:
             info = yaml.safe_load(f.read())
 
-        template_timestamp = _get_template_timestamp(artifacts_dir, FEDORA_MINIMAL, "build")
+        template_timestamp = _get_template_timestamp(
+            artifacts_dir, FEDORA_MINIMAL, "build"
+        )
 
         assert info.get("timestamp", []) == template_timestamp
         assert ["templates-itl-testing"] == [
@@ -2211,7 +2385,9 @@ def test_template_fedora_43_minimal_publish_new(artifacts_dir):
             parsedate(data["timestamp"]) + datetime.timedelta(minutes=1)
         ).strftime("%Y%m%d%H%M")
         data["timestamp"] = new_timestamp
-        with open(artifacts_dir / f"templates/{FEDORA_MINIMAL}.prep.yml", "w") as f:
+        with open(
+            artifacts_dir / f"templates/{FEDORA_MINIMAL}.prep.yml", "w"
+        ) as f:
             f.write(yaml.dump(data))
 
         qb_call(
@@ -2319,7 +2495,9 @@ def test_template_fedora_43_minimal_unpublish(artifacts_dir):
         env["GNUPGHOME"] = gnupghome
         env["HOME"] = tmpdir
 
-        template_timestamp = _get_template_timestamp(artifacts_dir, FEDORA_MINIMAL, "build")
+        template_timestamp = _get_template_timestamp(
+            artifacts_dir, FEDORA_MINIMAL, "build"
+        )
 
         # unpublish from templates-itl
         qb_call(
@@ -2374,7 +2552,9 @@ def test_template_fedora_43_minimal_unpublish(artifacts_dir):
 def test_template_fedora_for_iso(artifacts_dir):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
-        template_timestamp = _get_template_timestamp(artifacts_dir, FEDORA_MINIMAL, "build")
+        template_timestamp = _get_template_timestamp(
+            artifacts_dir, FEDORA_MINIMAL, "build"
+        )
         rpm = f"qubes-template-{FEDORA_MINIMAL}-4.2.0-{template_timestamp}.noarch.rpm"
 
         qb_call(

--- a/tests/test_cli_cleanup.py
+++ b/tests/test_cli_cleanup.py
@@ -17,8 +17,7 @@ HASH_RE = re.compile(r"[a-f0-9]{40}")
 
 class RandomData:
     COMPONENTS = [
-        "core-qrexec",
-        "core-vchan-xen",
+        "example-advanced",
     ]
     VERSIONS = ["1.0", "1.1", "1.2", "1.3"]
     DISTFILES = [f"distfile{i}.tar.gz" for i in range(1, 3)]
@@ -192,18 +191,20 @@ def test_cleanup_distfiles(artifacts_dir):
         DEFAULT_BUILDER_CONF,
         artifacts_dir,
         "-c",
-        "linux-gbulb",
+        "example-advanced",
         "package",
         "fetch",
     )
 
-    distfiles_dir = artifacts_dir / "distfiles" / "linux-gbulb"
+    distfiles_dir = artifacts_dir / "distfiles" / "example-advanced"
     distfiles_dir.mkdir(parents=True, exist_ok=True)
     dummy_file = distfiles_dir / "dummy.txt"
     dummy_file.write_text("dummy content")
     dummy_file2 = distfiles_dir / "dummy2.txt"
     dummy_file2.write_text("dummy content 2")
-    current_distfile = distfiles_dir / "gbulb-0.6.3.tar.gz"
+    current_distfile = (
+        distfiles_dir / "9FA64B92F95E706BF28E2CA6484010B5CDC576E2"
+    )
 
     qb_call(DEFAULT_BUILDER_CONF, artifacts_dir, "cleanup", "distfiles")
 
@@ -213,7 +214,7 @@ def test_cleanup_distfiles(artifacts_dir):
 
 
 def test_cleanup_build_artifacts(artifacts_dir):
-    components_dir = artifacts_dir / "components" / "linux-gbulb"
+    components_dir = artifacts_dir / "components" / "example-advanced"
     components_dir.mkdir(parents=True, exist_ok=True)
     for version in ["0.1.2-3", "0.4.5-6", "0.7.8-9", "1.0.0-1"]:
         old_version = components_dir / version
@@ -241,7 +242,7 @@ def test_cleanup_build_artifacts(artifacts_dir):
 
 
 def test_cleanup_build_artifacts_sequence(artifacts_dir):
-    components_dir = artifacts_dir / "components" / "linux-gbulb"
+    components_dir = artifacts_dir / "components" / "example-advanced"
     components_dir.mkdir(parents=True, exist_ok=True)
     for version in ["1.7", "1.8", "1.9", "1.10"]:
         old_version = components_dir / version
@@ -440,7 +441,7 @@ def test_cleanup_chroot_only_unused(artifacts_dir):
 
 
 def test_cleanup_distfiles_dry_run(artifacts_dir):
-    distfiles_dir = artifacts_dir / "distfiles" / "linux-gbulb"
+    distfiles_dir = artifacts_dir / "distfiles" / "example-advanced"
     distfiles_dir.mkdir(parents=True, exist_ok=True)
     dummy_file = distfiles_dir / "dummy.txt"
     dummy_file.write_text("dummy content")
@@ -453,7 +454,7 @@ def test_cleanup_distfiles_dry_run(artifacts_dir):
 
 
 def test_cleanup_build_artifacts_dry_run(artifacts_dir):
-    components_dir = artifacts_dir / "components" / "linux-gbulb"
+    components_dir = artifacts_dir / "components" / "example-advanced"
     components_dir.mkdir(parents=True, exist_ok=True)
     old_version = components_dir / "1.0.0"
     old_version.mkdir()

--- a/tests/test_cli_repository.py
+++ b/tests/test_cli_repository.py
@@ -62,7 +62,7 @@ def qb_call_output(builder_conf, artifacts_dir, release, *args, **kwargs):
 
 
 @pytest.mark.parametrize("release", releases)
-def test_repository_create_vm_fc40(artifacts_dir, release):
+def test_repository_create_vm_fc43(artifacts_dir, release):
     env = os.environ.copy()
     with tempfile.TemporaryDirectory() as tmpdir:
         gnupghome = f"{tmpdir}/gnupg"
@@ -88,9 +88,9 @@ def test_repository_create_vm_fc40(artifacts_dir, release):
             artifacts_dir,
             release,
             "-c",
-            "core-vchan-xen",
+            "example-advanced",
             "-d",
-            "vm-fc40",
+            "vm-fc43",
             "repository",
             "create",
             "current",
@@ -99,7 +99,7 @@ def test_repository_create_vm_fc40(artifacts_dir, release):
 
         metadata_dir = (
             artifacts_dir
-            / f"repository-publish/rpm/{release}/current/vm/fc40/repodata"
+            / f"repository-publish/rpm/{release}/current/vm/fc43/repodata"
         )
         assert (metadata_dir / "repomd.xml.metalink").exists()
         with open((metadata_dir / "repomd.xml"), "rb") as repomd_f:
@@ -107,7 +107,7 @@ def test_repository_create_vm_fc40(artifacts_dir, release):
         assert repomd_hash in (metadata_dir / "repomd.xml.metalink").read_text(
             encoding="ascii"
         )
-        assert f"/pub/os/qubes/repo/yum/{release}/current/vm/fc40/repodata/repomd.xml" in (
+        assert f"/pub/os/qubes/repo/yum/{release}/current/vm/fc43/repodata/repomd.xml" in (
             metadata_dir / "repomd.xml.metalink"
         ).read_text(
             encoding="ascii"
@@ -131,7 +131,7 @@ def test_repository_create_vm_bookworm(artifacts_dir, release):
                 artifacts_dir,
                 release,
                 "-c",
-                "core-vchan-xen",
+                "example-advanced",
                 "-d",
                 "vm-bookworm",
                 "repository",

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -82,13 +82,15 @@ def root_logger():
 
 def teardown_logging():
     """Reset logging configuration to default"""
-    if QubesBuilderLogger.handlers:
-        logging.shutdown()
-        import importlib
-
-        importlib.reload(logging)
-        QubesBuilderLogger.handlers = []
-        QubesBuilderLogger.filters = []
+    # Remove all child loggers created under the qb hierarchy so they don't
+    # pollute the global logger registry for subsequent test modules.
+    manager = logging.Logger.manager
+    prefix = QubesBuilderLogger.name + "."
+    stale = [k for k in list(manager.loggerDict) if k.startswith(prefix)]
+    for name in stale:
+        del manager.loggerDict[name]
+    QubesBuilderLogger.handlers.clear()
+    QubesBuilderLogger.filters.clear()
 
 
 def test_file_formatter():

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -572,7 +572,7 @@ def test_config_distributions_filter():
     with tempfile.NamedTemporaryFile("w") as config_file:
         config_file.write(
             """distributions:
- - vm-fc40
+ - vm-fc43
  - vm-bullseye
  - host-fc37
 """
@@ -581,18 +581,18 @@ def test_config_distributions_filter():
         config = Config(config_file.name)
 
         assert [d.distribution for d in config.get_distributions()] == [
-            "vm-fc40",
+            "vm-fc43",
             "vm-bullseye",
             "host-fc37",
         ]
         assert [
-            d.distribution for d in config.get_distributions(["vm-fc40"])
-        ] == ["vm-fc40"]
+            d.distribution for d in config.get_distributions(["vm-fc43"])
+        ] == ["vm-fc43"]
         assert [
             d.distribution
-            for d in config.get_distributions(["vm-fc40", "host-fc37"])
+            for d in config.get_distributions(["vm-fc43", "host-fc37"])
         ] == [
-            "vm-fc40",
+            "vm-fc43",
             "host-fc37",
         ]
         with pytest.raises(ConfigError):
@@ -603,8 +603,8 @@ def test_config_templates_filter():
     with tempfile.NamedTemporaryFile("w") as config_file:
         config_file.write(
             """templates:
-  - fedora-40-xfce:
-      dist: fc40
+  - fedora-43-xfce:
+      dist: fc43
       flavor: xfce
   - centos-stream-8:
       dist: centos-stream8
@@ -619,7 +619,7 @@ def test_config_templates_filter():
         config = Config(config_file.name)
 
         assert [t.name for t in config.get_templates()] == [
-            "fedora-40-xfce",
+            "fedora-43-xfce",
             "centos-stream-8",
             "debian-11",
         ]
@@ -628,9 +628,9 @@ def test_config_templates_filter():
         ]
         assert [
             t.name
-            for t in config.get_templates(["fedora-40-xfce", "debian-11"])
+            for t in config.get_templates(["fedora-43-xfce", "debian-11"])
         ] == [
-            "fedora-40-xfce",
+            "fedora-43-xfce",
             "debian-11",
         ]
         with pytest.raises(ConfigError):


### PR DESCRIPTION
- source_deb: support non-archive extra files with create-archive  
- Clean stale publish/repo state before template publish test.
- Update .gitlab-ci.yml: workflow rules, default values, fc40 -> fc43.