### PR TITLE
publish_deb: clean stale devel sources across the shared pool

### DIFF
--- a/qubesbuilder/plugins/publish_deb/__init__.py
+++ b/qubesbuilder/plugins/publish_deb/__init__.py
@@ -19,6 +19,8 @@
 import datetime
 from typing import Optional
 
+import yaml
+
 from qubesbuilder.distribution import QubesDistribution
 from qubesbuilder.executors import ExecutorError
 from qubesbuilder.plugins import Plugin, PluginContext, PluginDependency
@@ -68,6 +70,19 @@ class DEBRepoPlugin(Plugin):
             / f"{self.config.qubes_release}/{self.dist.package_set}"
         )
 
+    def _get_dists_sharing_pool(self):
+        # Same fullname only: create-skeleton rewrites conf/distributions
+        # per family, so removefilter against the other family's suites
+        # would error with "unknown distribution".
+        return [
+            d
+            for d in self.config.get_distributions()
+            if (d.is_deb() or d.is_ubuntu())
+            and d.type == self.dist.type
+            and d.package_set == self.dist.package_set
+            and d.fullname == self.dist.fullname
+        ]
+
     def create_repository_skeleton(self):
         artifacts_dir = self.config.repository_publish_dir / self.dist.type
 
@@ -102,14 +117,17 @@ class DEBRepoPlugin(Plugin):
             msg = f"{self.log_prefix}: Failed to create metadata."
             raise PublishError(msg) from e
 
-    def sign_metadata(self, repository_publish):
+    def sign_metadata(self, repository_publish, dist=None):
         """Sign repository metadata
 
         Do it manually, as reprepro does not support alternative gpg client"""
 
+        if dist is None:
+            dist = self.dist
+
         # Check if we have a signing key provided
         sign_key = self.config.sign_key.get(
-            self.dist.distribution, None
+            dist.distribution, None
         ) or self.config.sign_key.get("deb", None)
 
         if not sign_key:
@@ -124,7 +142,7 @@ class DEBRepoPlugin(Plugin):
             return
 
         debian_suite = self.get_debian_suite_from_repository_publish(
-            dist=self.dist, repository_publish=repository_publish
+            dist=dist, repository_publish=repository_publish
         )
 
         for opt, out_name in (
@@ -244,8 +262,17 @@ class DEBPublishPlugin(DEBRepoPlugin, PublishPlugin):
         self.sign_metadata(repository_publish=repository_publish)
 
     def unpublish(
-        self, executor, directory, repository_publish, build_info=None
+        self,
+        executor,
+        directory,
+        repository_publish,
+        build_info=None,
+        dist=None,
+        source_only=False,
     ):
+        if dist is None:
+            dist = self.dist
+
         # directory basename will be used as prefix for some artifacts
         directory_bn = directory.mangle()
 
@@ -259,12 +286,15 @@ class DEBPublishPlugin(DEBRepoPlugin, PublishPlugin):
             self.log.info(f"{self.log_prefix}:{directory}: Nothing to publish.")
             return
 
-        self.log.info(f"{self.log_prefix}:{directory}: Unpublishing packages.")
+        kind = "source" if source_only else "packages"
+        self.log.info(
+            f"{self.component}:{dist}:{directory}: Unpublishing {kind}."
+        )
 
         # Unpublishing packages
         target_dir = self.get_target_dir()
         debian_suite = self.get_debian_suite_from_repository_publish(
-            self.dist, repository_publish
+            dist, repository_publish
         )
         try:
             reprepro_options = f"--ignore=surprisingbinary --ignore=surprisingarch --delete -b {target_dir}"
@@ -273,17 +303,81 @@ class DEBPublishPlugin(DEBRepoPlugin, PublishPlugin):
             source_name, source_version = build_info[
                 "package-release-name-full"
             ].split("_", 1)
-            cmd = [
-                f"reprepro {reprepro_options} removefilter {debian_suite} '$Source (=={source_name}), $Version (=={source_version})'"
+            filter_parts = [
+                f"$Source (=={source_name})",
+                f"$Version (=={source_version})",
             ]
+            if source_only:
+                filter_parts.append("$Architecture (==source)")
+            filter_expr = ", ".join(filter_parts)
+            cmd = [
+                f"reprepro {reprepro_options} removefilter {debian_suite} '{filter_expr}'"
+            ]
+            if source_only:
+                # Tracking DB holds independent refs; removefilter alone
+                # leaves orig.tar.gz pinned in the shared pool.
+                cmd.append(
+                    f"reprepro {reprepro_options} removetrack {debian_suite} {source_name} {source_version}"
+                )
             executor.run(cmd)
         except ExecutorError as e:
-            msg = f"{self.component}:{self.dist}:{directory}: Failed to unpublish packages."
+            msg = f"{self.component}:{dist}:{directory}: Failed to unpublish packages."
             raise PublishError(msg) from e
 
         release_file = target_dir / "dists" / debian_suite / "Release"
         if release_file.exists():
-            self.sign_metadata(repository_publish=repository_publish)
+            self.sign_metadata(repository_publish=repository_publish, dist=dist)
+
+    def _cleanup_peer_stale_sources(self, executor, directory, build_info):
+        # In devel mode the orig.tar.gz has no devel suffix, so any other
+        # dist sharing the reprepro pool can still pin a previous one with
+        # a different checksum. Drop only the source triple from each peer
+        # (binary .debs stay). Persist the cleared repository-publish entry
+        # back so future runs don't re-issue removetrack on a missing key.
+        component_dir = (
+            self.config.artifacts_dir / "components" / self.component.name
+        ).resolve()
+        info_suffix = f".{self.stage}.yml"
+        for other_dist in self._get_dists_sharing_pool():
+            for hist_dir in component_dir.glob(
+                f"*/{other_dist.distribution}/{self.stage}"
+            ):
+                for info_file in hist_dir.glob(f"*{info_suffix}"):
+                    hist_info = self._get_artifacts_info(info_file)
+                    if not hist_info:
+                        continue
+                    if hist_info.get("source-hash") == build_info.get(
+                        "source-hash"
+                    ):
+                        continue
+                    if "package-release-name-full" not in hist_info:
+                        continue
+                    repos = hist_info.get("repository-publish") or []
+                    if not repos:
+                        continue
+                    self.log.info(
+                        f"{self.component}:{other_dist}:{directory}: "
+                        f"Found stale source publication with different "
+                        f"source hash, cleaning up."
+                    )
+                    cleared = []
+                    try:
+                        for repo_entry in repos:
+                            self.unpublish(
+                                executor=executor,
+                                directory=directory,
+                                repository_publish=repo_entry["name"],
+                                build_info=hist_info,
+                                dist=other_dist,
+                                source_only=True,
+                            )
+                            cleared.append(repo_entry)
+                    finally:
+                        hist_info["repository-publish"] = [
+                            r for r in repos if r not in cleared
+                        ]
+                        with open(info_file, "w") as f:
+                            yaml.safe_dump(hist_info, f)
 
     def run(
         self,
@@ -407,45 +501,11 @@ class DEBPublishPlugin(DEBRepoPlugin, PublishPlugin):
                             )
                     else:
                         info = publish_info
-                elif self.config.increment_devel_versions:
-                    # No publish info for this version. Check history for old
-                    # devel publications that may still be in the reprepro pool
-                    # with a different checksum.
-                    for (
-                        hist_publish_dir
-                    ) in self.get_dist_component_artifacts_dir_history(
-                        stage=self.stage
-                    ):
-                        hist_publish_info = self.get_dist_artifacts_info(
-                            stage=self.stage,
-                            basename=directory_bn,
-                            artifacts_dir=hist_publish_dir,
-                        )
-                        if not hist_publish_info:
-                            continue
-                        if hist_publish_info.get(
-                            "source-hash"
-                        ) == build_info.get("source-hash"):
-                            continue
-                        # Old publication with a different source hash.
-                        self.log.info(
-                            f"{self.component}:{self.dist}:{directory}: "
-                            f"Found stale publication with different source hash, cleaning up."
-                        )
-                        for repo_entry in hist_publish_info.get(
-                            "repository-publish", []
-                        ):
-                            self.unpublish(
-                                executor=self.executor,
-                                directory=directory,
-                                repository_publish=repo_entry["name"],
-                                build_info=hist_publish_info,
-                            )
-                        self.delete_dist_artifacts_info(
-                            stage=self.stage,
-                            basename=directory_bn,
-                            artifacts_dir=hist_publish_dir,
-                        )
+
+                if self.config.increment_devel_versions:
+                    self._cleanup_peer_stale_sources(
+                        self.executor, directory, build_info
+                    )
 
                 self.publish(
                     executor=self.executor,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1752,16 +1752,247 @@ def test_publish_deb_no_source_conflict(artifacts_dir_single):
             "|main|source: qubes-example-advanced" in p for p in packages
         )
 
-        # The stale devel=1 publication must have been cleaned from current-testing
-        # (its orig.tar.gz removed from the pool) before devel=2 could be published.
+        # The stale devel=1 source must have been cleaned from current-testing
+        # (orig.tar.gz freed from the shared pool) before devel=2 could be
+        # published to unstable, but the devel=1 binaries that were explicitly
+        # published to current-testing remain.
         packages_testing = deb_packages_list(repository_dir, "trixie-testing")
-        assert not any(
-            "qubes-example-advanced" in p and "devel1" in p
+        assert any(
+            "|main|amd64:" in p
+            and "qubes-example-advanced" in p
+            and "devel1" in p
             for p in packages_testing
         )
         assert not any(
             "|main|source: qubes-example-advanced" in p and "devel1" in p
             for p in packages_testing
+        )
+
+
+def test_publish_deb_no_source_conflict_cross_dist(artifacts_dir_single):
+    # QubesOS/qubes-issues#10555: a stale devel source in another suite of
+    # the shared reprepro pool must not block re-publishing the same
+    # source from a different one, and the peer's binary .debs must stay
+    # in place.
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "-d",
+            "vm-trixie",
+            "package",
+            "fetch",
+            "prep",
+            "build",
+            "sign",
+            env=env,
+        )
+
+        assert (
+            artifacts_dir_single / "components/example-advanced/noversion/devel"
+        ).read_text(encoding="utf-8") == "1"
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "-d",
+            "vm-trixie",
+            "repository",
+            "publish",
+            "current-testing",
+            env=env,
+        )
+
+        repository_dir = artifacts_dir_single / "repository-publish/deb/r4.2/vm"
+        for suite in ("bookworm-testing", "trixie-testing"):
+            packages = deb_packages_list(repository_dir, suite)
+            assert any(
+                "qubes-example-advanced" in p and "devel1" in p
+                for p in packages
+            ), f"{suite} should contain devel1 before the source change"
+
+        # Bump source so the next orig.tar.gz checksum differs.
+        (artifacts_dir_single / "sources/example-advanced/hello").write_text(
+            "world", encoding="utf8"
+        )
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "package",
+            "fetch",
+            env=env,
+        )
+
+        assert (
+            artifacts_dir_single / "components/example-advanced/noversion/devel"
+        ).read_text(encoding="utf-8") == "2"
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "package",
+            "prep",
+            "build",
+            "sign",
+            env=env,
+        )
+
+        # Before the fix this fails: trixie-testing still pins the old
+        # orig.tar.gz so reprepro rejects the new one with conflicting
+        # checksums.
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "repository",
+            "publish",
+            "current-testing",
+            env=env,
+        )
+
+        bookworm_pkgs = deb_packages_list(repository_dir, "bookworm-testing")
+        assert any(
+            "qubes-example-advanced" in p and "devel2" in p
+            for p in bookworm_pkgs
+        )
+        assert any(
+            "|main|source: qubes-example-advanced" in p and "devel2" in p
+            for p in bookworm_pkgs
+        )
+        assert not any(
+            "qubes-example-advanced" in p and "devel1" in p
+            for p in bookworm_pkgs
+        )
+
+        # trixie-testing keeps its devel1 binary .debs (only the source
+        # triple was dropped so the shared orig.tar.gz could be freed).
+        trixie_pkgs = deb_packages_list(repository_dir, "trixie-testing")
+        assert any(
+            "|main|amd64:" in p
+            and "qubes-example-advanced" in p
+            and "devel1" in p
+            for p in trixie_pkgs
+        )
+        assert not any(
+            "|main|source: qubes-example-advanced" in p and "devel1" in p
+            for p in trixie_pkgs
+        )
+
+        # Second pipeline scenario: bookworm already has a prior publish
+        # (devel2 above), source changes again, bookworm re-publishes
+        # devel3 while trixie still pins its devel1 orig in the pool.
+        # This exercises the `if publish_info` branch, which must also
+        # run the cross-dist source cleanup.
+        (artifacts_dir_single / "sources/example-advanced/hello").write_text(
+            "world2", encoding="utf8"
+        )
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "package",
+            "fetch",
+            env=env,
+        )
+
+        assert (
+            artifacts_dir_single / "components/example-advanced/noversion/devel"
+        ).read_text(encoding="utf-8") == "3"
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "package",
+            "prep",
+            "build",
+            "sign",
+            env=env,
+        )
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir_single,
+            "--option",
+            "increment-devel-versions=true",
+            "-c",
+            "example-advanced",
+            "-d",
+            "vm-bookworm",
+            "repository",
+            "publish",
+            "current-testing",
+            env=env,
+        )
+
+        bookworm_pkgs = deb_packages_list(repository_dir, "bookworm-testing")
+        assert any(
+            "qubes-example-advanced" in p and "devel3" in p
+            for p in bookworm_pkgs
+        )
+        assert not any(
+            "qubes-example-advanced" in p and "devel2" in p
+            for p in bookworm_pkgs
+        )
+
+        trixie_pkgs = deb_packages_list(repository_dir, "trixie-testing")
+        assert any(
+            "|main|amd64:" in p
+            and "qubes-example-advanced" in p
+            and "devel1" in p
+            for p in trixie_pkgs
+        )
+        assert not any(
+            "|main|source: qubes-example-advanced" in p and "devel1" in p
+            for p in trixie_pkgs
         )
 
 


### PR DESCRIPTION
orig.tar.gz carries no devel suffix, so any other dist sharing the reprepro pool keeps pinning the previous one and reprepro rejects the new orig with conflicting checksums. Walk every Debian/Ubuntu dist sharing the target_dir and removefilter the stale source from each.

QubesOS/qubes-issues#10555