### PR TITLE
Fix creating archive out of git upstream sources

### DIFF
--- a/qubesbuilder/plugins/fetch/__init__.py
+++ b/qubesbuilder/plugins/fetch/__init__.py
@@ -462,7 +462,7 @@ class FetchPlugin(Plugin):
         cmd = [
             f"cd {str(executor.get_builder_dir())}",
             " ".join(get_sources_cmd),
-            f"{executor.get_plugins_dir()}/fetch/scripts/create-archive {source_dir} {archive_name} {archive_base}/",
+            f"{executor.get_plugins_dir()}/fetch/scripts/create-archive --no-gitignore {source_dir} {archive_name} {archive_base}/",
         ]
 
         copy_out = [(source_dir / archive_name, distfiles_dir)]

--- a/qubesbuilder/plugins/fetch/scripts/create-archive
+++ b/qubesbuilder/plugins/fetch/scripts/create-archive
@@ -28,6 +28,12 @@ set -e
 
 TAR_VERSION="$(tar --version | head -1 | awk '{print $4}')"
 
+exclude_opts=( --exclude-vcs-ignores )
+if [ "$1" = "--no-gitignore" ]; then
+    exclude_opts=()
+    shift
+fi
+
 GIT_ARCHIVE_SRC="$(readlink -f "$1")"
 GIT_ARCHIVE_TYPE="${2##*.}"
 GIT_TARBALL_NAME="${2%."$GIT_ARCHIVE_TYPE"}"
@@ -59,7 +65,7 @@ if [ "$(printf '%s\n' "$TAR_VERSION" "1.28" | sort -V | head -n1)" == "1.28" ]; 
         --owner=0 --group=0 --numeric-owner \
         --mode=go=rX \
         --xform="s%^\./%${GIT_ARCHIVE_PREFIX}%" \
-        --exclude-vcs-ignores \
+        "${exclude_opts[@]}" \
         --exclude-ignore=.tarignore \
         --exclude pkgs --exclude '.git/*' --exclude "${GIT_TARBALL_NAME}" \
         -cf "${GIT_TARBALL_NAME}" .

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -177,6 +177,7 @@ run_pytest() {
         -rA
         -o truncation_limit_chars=0
         -o truncation_limit_lines=0
+        -o norecursedirs='artifacts*'
         -o junit_logging=all
         --junitxml=artifacts/qubesbuilder.xml
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import uuid
 
 import pytest
 
+from qubesbuilder.common import PROJECT_PATH
+
 # Redirect all temporary files to home
 _default_tmpdir = os.path.join(os.path.expanduser("~"), "qb-test-tmp")
 os.makedirs(_default_tmpdir, exist_ok=True)
@@ -120,3 +122,26 @@ def artifacts_dir(pytestconfig):
     if cache_dir:
         _seed_cache(cache_dir, root)
     yield root
+
+
+@pytest.fixture
+def home_directory(temp_directory):
+    gnupghome = f"{temp_directory}/gnupg"
+    shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+    os.chmod(gnupghome, 0o700)
+    # Initialize the conf
+    with open(f"{temp_directory}/.gitconfig", "w") as gitconfig:
+        gitconfig.write(
+            "[user]\nname=testuser\nemail=test@localhost\n[gpg]\nprogram=gpg2"
+        )
+    yield temp_directory
+
+
+@pytest.fixture
+def temp_directory():
+    # Create a temporary directory
+    temp_dir = pathlib.Path(tempfile.mkdtemp())
+    yield temp_dir
+    # Remove the temporary directory after the test
+    if temp_dir.exists():
+        shutil.rmtree(temp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -479,6 +479,80 @@ def test_common_component_fetch_commit_fresh(artifacts_dir_single):
     assert info["git-commit-hash"] == commit_sha
 
 
+def create_source_repo(repo_dir, home_directory):
+    env = {"HOME": home_directory}
+    repo_dir.mkdir(exist_ok=False, parents=True)
+    (repo_dir / "README.md").touch()
+    (repo_dir / "test.txt").touch()
+    with open(repo_dir / ".gitignore", "w") as f:
+        f.write("*.md\n")
+        f.write("!README.md\n")
+    subprocess.check_call(["git", "-C", repo_dir, "init"], env=env)
+    subprocess.check_call(["git", "-C", repo_dir, "add", "."], env=env)
+    subprocess.check_call(
+        ["git", "-C", repo_dir, "commit", "-m", "Initial commit"], env=env
+    )
+    commit_sha = (
+        subprocess.check_output(["git", "-C", repo_dir, "rev-parse", "HEAD"])
+        .decode()
+        .strip()
+    )
+    return commit_sha
+
+
+def test_common_component_fetch_git_archive(
+    artifacts_dir_single, home_directory
+):
+    artifacts_dir = artifacts_dir_single
+    # download base component first
+    result = qb_call_output(
+        DEFAULT_BUILDER_CONF,
+        artifacts_dir,
+        "-c",
+        "example-advanced",
+        "package",
+        "fetch",
+    )
+    # create "upstream" source
+    repo_dir = artifacts_dir / "tmp" / "repo"
+    commit_sha = create_source_repo(repo_dir, home_directory)
+    with open(
+        artifacts_dir / "sources" / "example-advanced" / ".qubesbuilder", "w"
+    ) as f:
+        f.write("host:\n")
+        f.write("  rpm:\n")
+        f.write("    build:\n")
+        f.write("    - rpm_spec/example-dom0.spec\n")
+        f.write("source:\n")
+        f.write("  files:\n")
+        f.write(f"  - git-url: file://{repo_dir}\n")
+        f.write(f"    git-basename: repo-advanced-1.2.3\n")
+        f.write(f"    commit-id: {commit_sha}\n")
+    # re-download, with adjusted .qubesbuilder
+    result = qb_call_output(
+        DEFAULT_BUILDER_CONF,
+        artifacts_dir,
+        "-o",
+        "skip-git-fetch=true",
+        "-o",
+        "executor:type=local",
+        "-c",
+        "example-advanced",
+        "package",
+        "fetch",
+    )
+    archive_path = (
+        artifacts_dir
+        / "distfiles"
+        / "example-advanced"
+        / "repo-advanced-1.2.3.tar.gz"
+    )
+    assert archive_path.exists()
+    contents = subprocess.check_output(["tar", "-tf", archive_path])
+    # file that is excluded by wildcard and later re-included by path
+    assert b"\nrepo-advanced-1.2.3/README.md" in contents
+
+
 def test_common_existent_command(artifacts_dir):
     result = qb_call(
         DEFAULT_BUILDER_CONF,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,11 +1,8 @@
 import importlib
-import os
-import pathlib
 import random
 import shutil
 import string
 import subprocess
-import tempfile
 from argparse import Namespace
 
 import pytest
@@ -15,29 +12,6 @@ from qubesbuilder.common import PROJECT_PATH
 get_and_verify_source = importlib.import_module(
     "qubesbuilder.plugins.fetch.scripts.get-and-verify-source"
 ).main
-
-
-@pytest.fixture
-def temp_directory():
-    # Create a temporary directory
-    temp_dir = pathlib.Path(tempfile.mkdtemp())
-    yield temp_dir
-    # Remove the temporary directory after the test
-    if temp_dir.exists():
-        shutil.rmtree(temp_dir)
-
-
-@pytest.fixture
-def home_directory(temp_directory):
-    gnupghome = f"{temp_directory}/gnupg"
-    shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
-    os.chmod(gnupghome, 0o700)
-    # Initialize the conf
-    with open(f"{temp_directory}/.gitconfig", "w") as gitconfig:
-        gitconfig.write(
-            "[user]\nname=testuser\nemail=test@localhost\n[gpg]\nprogram=gpg2"
-        )
-    yield temp_directory
 
 
 def create_git_repository(repo_dir, env, sign_commit=False, sign_key=None):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -54,6 +54,16 @@ def create_git_repository(repo_dir, env, sign_commit=False, sign_key=None):
         env=env,
     )
 
+    if sign_commit and sign_key:
+        subprocess.run(
+            ["git", "config", "user.signingkey", sign_key],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
+            cwd=repo_dir,
+        )
+
     # Add some commits to the repository
     for i in range(1, 5):
         with open(repo_dir / f"file{i}.txt", "w") as file:
@@ -63,14 +73,6 @@ def create_git_repository(repo_dir, env, sign_commit=False, sign_key=None):
         )
         commit_cmd = ["git", "commit", "-m", f"Commit {i}"]
         if sign_commit and sign_key:
-            subprocess.run(
-                ["git", "config", "user.signingkey", sign_key],
-                capture_output=True,
-                text=True,
-                check=True,
-                env=env,
-                cwd=repo_dir,
-            )
             commit_cmd += ["-S"]
         subprocess.run(
             commit_cmd,


### PR DESCRIPTION
Linux 7.1-rc3 has this in top-level .gitignore:

    *.bc
    ...
    !kernel/time/timeconst.bc

`tar --exclude-vcs-ignores` doesn't support negated entries, so
kernel/time/timeconst.bc gets excluded from the final tarball.
Fix this by not using `tar --exclude-vcs-ignores` on a repository that is a
fresh clone anyway.