### PR TITLE
Fix template version for devel templates

### DIFF
--- a/qubesbuilder/config.py
+++ b/qubesbuilder/config.py
@@ -45,7 +45,7 @@ from qubesbuilder.plugins import (
 )
 from qubesbuilder.template import QubesTemplate
 
-QUBES_RELEASE_RE = re.compile(r"r([1-9]\.[0-9]+).*")
+QUBES_RELEASE_RE = re.compile(r"r([1-9]+\.[0-9]+).*")
 QUBES_RELEASE_DEFAULT = "r4.2"
 
 
@@ -616,7 +616,7 @@ class Config:
     def parse_qubes_release(self):
         qubes_release = self.qubes_release
         if qubes_release == "devel":
-            qubes_release = "99.0"
+            qubes_release = "r99.0"
         parsed_release = QUBES_RELEASE_RE.match(
             qubes_release
         ) or QUBES_RELEASE_RE.match(QUBES_RELEASE_DEFAULT)


### PR DESCRIPTION
Make the 99.0 actually pass validation.

Fixes: 02b5c52 "Parse 'devel' version as '99.0'"
