### PR TITLE
Include forky in pbuilderrc

### DIFF
--- a/qubesbuilder/plugins/chroot_deb/pbuilder/pbuilderrc
+++ b/qubesbuilder/plugins/chroot_deb/pbuilder/pbuilderrc
@@ -14,7 +14,7 @@ LOGLEVEL=I
 USECOLORS=auto
 
 case ${DISTRIBUTION} in
-    buster|bullseye|bookworm|trixie|sid|experimental)
+    buster|bullseye|bookworm|trixie|forky|sid|experimental)
         DIST_VENDOR=debian
         MIRRORSITE=https://deb.debian.org/debian
         ;;
@@ -61,7 +61,7 @@ BUILDRESULT="@BUILDER_DIR@/pbuilder/results"
 # components on Debian use "main contrib non-free" and on Ubuntu "main
 # restricted universe multiverse"
 case ${DISTRIBUTION} in
-    buster|bullseye|bookworm|trixie|sid|experimental)
+    buster|bullseye|bookworm|trixie|forky|sid|experimental)
         COMPONENTS="main"
         ;;
     bionic|focal|jammy|noble)


### PR DESCRIPTION
Last part for building packages for forky.

Fixes: 5ba1a3f "Debian - add support for forky"
QubesOS/qubes-issues#10930
