### PR TITLE
Fix Arch repository metadata creation

### DIFF
--- a/qubesbuilder/plugins/publish_archlinux/__init__.py
+++ b/qubesbuilder/plugins/publish_archlinux/__init__.py
@@ -50,6 +50,7 @@ class ArchlinuxRepoPlugin(Plugin):
         self.log_prefix = f"{self.name}:{self.dist}"
 
     def get_repository_db(self, repository_publish):
+        assert self.dist is not None
         target_dir = (
             self.config.repository_publish_dir
             / self.dist.type
@@ -115,6 +116,7 @@ class ArchlinuxRepoPlugin(Plugin):
         return repository_db
 
     def create_and_sign_repository_metadata(self, repository_publish):
+        assert self.dist is not None
         executor = self.config.get_executor_from_config("publish", self)
 
         sign_key = self.config.sign_key.get(
@@ -328,6 +330,7 @@ class ArchlinuxPublishPlugin(ArchlinuxRepoPlugin, PublishPlugin):
         repository_publish: Optional[str] = None,
         ignore_min_age: bool = False,
         unpublish: bool = False,
+        create_and_sign_metadata_only: bool = False,
         **kwargs,
     ):
         """

--- a/qubesbuilder/plugins/publish_archlinux/__init__.py
+++ b/qubesbuilder/plugins/publish_archlinux/__init__.py
@@ -18,6 +18,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import datetime
 import os
+import shlex
+import tarfile
 from typing import Optional
 
 from qubesbuilder.executors import ExecutorError
@@ -47,11 +49,124 @@ class ArchlinuxRepoPlugin(Plugin):
 
         self.log_prefix = f"{self.name}:{self.dist}"
 
+    def get_repository_db(self, repository_publish):
+        target_dir = (
+            self.config.repository_publish_dir
+            / self.dist.type
+            / self.config.qubes_release
+            / repository_publish
+            / self.dist.package_set
+            / self.dist.name
+            / "pkgs"
+        )
+        return (
+            target_dir
+            / f"qubes-{self.config.qubes_release}-{repository_publish}.db.tar.gz"
+        )
+
+    def create_repository_metadata(self, executor, repository_publish):
+        repository_db = self.get_repository_db(repository_publish)
+        repository_files = repository_db.with_name(
+            repository_db.name.replace(".db.tar.gz", ".files.tar.gz")
+        )
+        repository_db_link = repository_db.with_name(
+            repository_db.name.removesuffix(".tar.gz")
+        )
+        repository_files_link = repository_files.with_name(
+            repository_files.name.removesuffix(".tar.gz")
+        )
+        repository_db.parent.mkdir(parents=True, exist_ok=True)
+
+        for metadata in (
+            repository_db,
+            repository_files,
+            repository_db_link,
+            repository_files_link,
+        ):
+            metadata.unlink(missing_ok=True)
+
+        packages = [
+            package
+            for package in repository_db.parent.glob("*.pkg.tar.*")
+            if not package.name.endswith(".sig")
+        ]
+        if packages:
+            packages_dir = shlex.quote(str(repository_db.parent))
+            repository_db_quoted = shlex.quote(str(repository_db))
+            cmd = [
+                f"find {packages_dir} -maxdepth 1 -type f "
+                "-name '*.pkg.tar.*' ! -name '*.sig' -print0 | "
+                f"sort -zV | xargs -0 -r repo-add {repository_db_quoted}"
+            ]
+            try:
+                executor.run(cmd)
+            except ExecutorError as e:
+                msg = f"{self.log_prefix}: Failed to create metadata."
+                raise PublishError(msg) from e
+        else:
+            # repo-add no longer creates an empty repository, so initialize
+            # both metadata archives directly.
+            for metadata in (repository_db, repository_files):
+                with tarfile.open(metadata, "w:gz"):
+                    pass
+            repository_db_link.symlink_to(repository_db.name)
+            repository_files_link.symlink_to(repository_files.name)
+
+        return repository_db
+
+    def create_and_sign_repository_metadata(self, repository_publish):
+        executor = self.config.get_executor_from_config("publish", self)
+
+        sign_key = self.config.sign_key.get(
+            self.dist.distribution, None
+        ) or self.config.sign_key.get("archlinux", None)
+        if not sign_key:
+            self.log.info(f"{self.log_prefix}: No signing key found.")
+            return
+
+        if not self.config.gpg_client:
+            self.log.info(
+                f"{self.log_prefix}: Please specify GPG client to use!"
+            )
+            return
+
+        repository_db = self.create_repository_metadata(
+            executor=executor, repository_publish=repository_publish
+        )
+        self.sign_metadata(
+            executor=executor,
+            directory=repository_db.parent,
+            sign_key=sign_key,
+            repository_db=repository_db,
+        )
+
+    def create(self, repository_publish: Optional[str]):
+        if not repository_publish:
+            self.log.error("Cannot create repository without repository name!")
+            return
+
+        self.create_and_sign_repository_metadata(
+            repository_publish=repository_publish
+        )
+
+    def run(
+        self,
+        repository_publish: Optional[str] = None,
+        ignore_min_age: bool = False,
+        unpublish: bool = False,
+        create_and_sign_metadata_only: bool = False,
+        **kwargs,
+    ):
+        if create_and_sign_metadata_only:
+            self.create(repository_publish)
+        else:
+            super().run()
+
     def sign_metadata(self, executor, directory, sign_key, repository_db):
         self.log.info(f"{self.log_prefix}:{directory}: Signing metadata.")
         repository_db_sig = repository_db.with_suffix(".gz.sig")
         cmd = [
-            f"{self.config.gpg_client} --batch --no-tty --yes --detach-sign --armor -u {sign_key} {repository_db} > {repository_db_sig}",
+            f"{self.config.gpg_client} --batch --no-tty --yes --detach-sign --armor --output - -u {sign_key} {repository_db} > {repository_db_sig}",
         ]
         try:
             executor.run(cmd)
@@ -398,4 +513,4 @@ class ArchlinuxPublishPlugin(ArchlinuxRepoPlugin, PublishPlugin):
                     )
 
 
-PLUGINS = [ArchlinuxPublishPlugin]
+PLUGINS = [ArchlinuxRepoPlugin, ArchlinuxPublishPlugin]

--- a/tests/test_cli_repository.py
+++ b/tests/test_cli_repository.py
@@ -4,6 +4,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+import tarfile
 import tempfile
 
 import pytest
@@ -146,6 +147,61 @@ def test_repository_create_vm_bookworm(artifacts_dir, release):
             assert (
                 repository_dir / "dists" / codename / "Release.gpg"
             ).exists()
+
+
+@pytest.mark.parametrize("release", releases)
+def test_repository_create_vm_archlinux(artifacts_dir, release):
+    env = os.environ.copy()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        gnupghome = f"{tmpdir}/gnupg"
+        shutil.copytree(PROJECT_PATH / "tests/gnupg", gnupghome)
+        os.chmod(gnupghome, 0o700)
+
+        env["GNUPGHOME"] = gnupghome
+        env["HOME"] = tmpdir
+
+        qb_call(
+            DEFAULT_BUILDER_CONF,
+            artifacts_dir,
+            release,
+            "-d",
+            "vm-archlinux",
+            "repository",
+            "create",
+            "current-testing",
+            env=env,
+        )
+
+        metadata_dir = (
+            artifacts_dir
+            / f"repository-publish/archlinux/{release}/current-testing/vm/archlinux/pkgs"
+        )
+        repository_db = (
+            metadata_dir / f"qubes-{release}-current-testing.db.tar.gz"
+        )
+        repository_files = (
+            metadata_dir / f"qubes-{release}-current-testing.files.tar.gz"
+        )
+        repository_db_sig = repository_db.with_suffix(".gz.sig")
+        assert repository_db.exists()
+        assert repository_files.exists()
+        assert repository_db_sig.exists()
+        assert repository_db.with_name(
+            repository_db.name.removesuffix(".tar.gz")
+        ).is_symlink()
+        assert repository_files.with_name(
+            repository_files.name.removesuffix(".tar.gz")
+        ).is_symlink()
+        with tarfile.open(repository_db) as repository:
+            assert repository.getnames() == []
+        with tarfile.open(repository_files) as repository:
+            assert repository.getnames() == []
+        subprocess.run(
+            ["gpg2", "-q", "--verify", repository_db_sig, repository_db],
+            check=True,
+            capture_output=True,
+            env=env,
+        )
 
 
 @pytest.mark.parametrize("release", releases)

--- a/tests/test_cli_repository.py
+++ b/tests/test_cli_repository.py
@@ -6,10 +6,17 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 from qubesbuilder.common import PROJECT_PATH
+from qubesbuilder.distribution import QubesDistribution
+from qubesbuilder.executors import ExecutorError
+from qubesbuilder.plugins import Plugin
+from qubesbuilder.plugins.publish import PublishError
+from qubesbuilder.plugins.publish_archlinux import ArchlinuxRepoPlugin
 
 DEFAULT_BUILDER_CONF = PROJECT_PATH / "tests/builder-ci.yml"
 HASH_RE = re.compile(r"[a-f0-9]{40}")
@@ -60,6 +67,88 @@ def qb_call_output(builder_conf, artifacts_dir, release, *args, **kwargs):
         *args,
     ]
     return subprocess.check_output(cmd, **kwargs)
+
+
+def _archlinux_repo_plugin(tmp_path):
+    plugin = object.__new__(ArchlinuxRepoPlugin)
+    plugin.config = SimpleNamespace(
+        repository_publish_dir=tmp_path,
+        qubes_release="r4.2",
+        sign_key={"archlinux": "test-key"},
+        gpg_client="gpg2",
+        get_executor_from_config=Mock(),
+    )
+    plugin.dist = QubesDistribution("vm-archlinux")
+    plugin.log = Mock()
+    plugin.log_prefix = f"{plugin.name}:{plugin.dist}"
+    return plugin
+
+
+def test_repository_archlinux_metadata_with_packages(tmp_path):
+    plugin = _archlinux_repo_plugin(tmp_path)
+    repository_db = plugin.get_repository_db("current-testing")
+    repository_db.parent.mkdir(parents=True)
+    (repository_db.parent / "example.pkg.tar.zst").touch()
+    (repository_db.parent / "example.pkg.tar.zst.sig").touch()
+    executor = Mock()
+
+    assert plugin.create_repository_metadata(executor, "current-testing") == repository_db
+    command = executor.run.call_args.args[0][0]
+    assert "repo-add" in command
+    assert "! -name '*.sig'" in command
+
+
+def test_repository_archlinux_metadata_wraps_executor_error(tmp_path):
+    plugin = _archlinux_repo_plugin(tmp_path)
+    repository_db = plugin.get_repository_db("current-testing")
+    repository_db.parent.mkdir(parents=True)
+    (repository_db.parent / "example.pkg.tar.zst").touch()
+    executor = Mock()
+    executor.run.side_effect = ExecutorError("repo-add failed")
+
+    with pytest.raises(PublishError, match="Failed to create metadata"):
+        plugin.create_repository_metadata(executor, "current-testing")
+
+
+@pytest.mark.parametrize(
+    ("sign_key", "gpg_client", "message"),
+    [
+        ({}, "gpg2", "No signing key found"),
+        ({"archlinux": "test-key"}, None, "Please specify GPG client"),
+    ],
+)
+def test_repository_archlinux_requires_signing_configuration(
+    tmp_path, sign_key, gpg_client, message
+):
+    plugin = _archlinux_repo_plugin(tmp_path)
+    plugin.config.sign_key = sign_key
+    plugin.config.gpg_client = gpg_client
+    plugin.create_repository_metadata = Mock()
+
+    plugin.create_and_sign_repository_metadata("current-testing")
+
+    plugin.create_repository_metadata.assert_not_called()
+    assert message in plugin.log.info.call_args.args[0]
+
+
+def test_repository_archlinux_create_requires_name(tmp_path):
+    plugin = _archlinux_repo_plugin(tmp_path)
+    plugin.create_and_sign_repository_metadata = Mock()
+
+    plugin.create(None)
+
+    plugin.create_and_sign_repository_metadata.assert_not_called()
+    plugin.log.error.assert_called_once()
+
+
+def test_repository_archlinux_run_delegates(tmp_path, monkeypatch):
+    plugin = _archlinux_repo_plugin(tmp_path)
+    delegated = []
+    monkeypatch.setattr(Plugin, "run", lambda self: delegated.append(self))
+
+    plugin.run()
+
+    assert delegated == [plugin]
 
 
 @pytest.mark.parametrize("release", releases)


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#9220.

The Arch Linux publish plugin had no distribution-level implementation for the metadata-only mode used by `qb repository create`, and the repository-level plugin was not registered. As a result, the command returned successfully without creating anything.

This adds the missing repository creation path. It rebuilds metadata from packages already present in the target repository, creates valid empty database and files archives when no packages exist, provides the standard pacman compatibility symlinks, and signs the database. The signing command now explicitly writes the detached signature to stdout so the intended `.sig` file contains the signature instead of being empty.

AI usage disclosure: AI assistance was used to investigate the issue, develop the patch, and prepare this pull request. The submitter reviewed the resulting changes.
